### PR TITLE
Merge ssl context pr

### DIFF
--- a/src/main/java/TestNotificationClient.java
+++ b/src/main/java/TestNotificationClient.java
@@ -82,6 +82,7 @@ public class TestNotificationClient {
                 break;
         }
         NotificationList notificationList = client.getNotifications(status, notificationType);
+        System.out.println(notificationList);
     }
 
     private static void createFetchNotificationByIdRequest(NotificationClient client) throws IOException, NotificationClientException {
@@ -89,6 +90,7 @@ public class TestNotificationClient {
         System.out.println("Enter the notification id to fetch: ");
         String notificationId = reader.readLine();
         Notification notification = client.getNotificationById(notificationId);
+        System.out.println(notification);
     }
 
     private static void createPostRequest(NotificationClient client) throws IOException, NotificationClientException {
@@ -130,9 +132,11 @@ public class TestNotificationClient {
         }
         if (messageType.equals("sms")){
             NotificationResponse response = client.sendSms(templateId, to, properties);
+            System.out.println(response);
         }
         else{
             NotificationResponse response = client.sendEmail(templateId, to, properties);
+            System.out.println(response);
         }
     }
 }

--- a/src/main/java/uk/gov/service/notify/Notification.java
+++ b/src/main/java/uk/gov/service/notify/Notification.java
@@ -142,4 +142,29 @@ public class Notification {
     public int getJobRowNumber() {
         return jobRowNumber;
     }
+
+    @Override
+    public String toString() {
+        return "Notification{" +
+                "id='" + id + '\'' +
+                ", body='" + body + '\'' +
+                ", contentCharCount=" + contentCharCount +
+                ", notificationType='" + notificationType + '\'' +
+                ", reference='" + reference + '\'' +
+                ", subject='" + subject + '\'' +
+                ", templateId='" + templateId + '\'' +
+                ", templateName='" + templateName + '\'' +
+                ", templateVersion=" + templateVersion +
+                ", to='" + to + '\'' +
+                ", sentBy='" + sentBy + '\'' +
+                ", sentAt=" + sentAt +
+                ", status='" + status + '\'' +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", apiKey='" + apiKey + '\'' +
+                ", jobId='" + jobId + '\'' +
+                ", jobFileName='" + jobFileName + '\'' +
+                ", jobRowNumber=" + jobRowNumber +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -1,11 +1,13 @@
 package uk.gov.service.notify;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.*;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -23,6 +25,11 @@ public class NotificationClient implements NotificationClientApi {
 
     public NotificationClient(String secret, String issuer, String baseUrl) {
         this(secret, issuer, baseUrl, null);
+        try {
+            setDefaultSSLContext();
+        } catch (NoSuchAlgorithmException e) {
+            LOGGER.log(Level.SEVERE, e.toString(), e);
+        }
     }
 
     public NotificationClient(String secret, String issuer, String baseUrl, Proxy proxy) {
@@ -183,5 +190,19 @@ public class NotificationClient implements NotificationClientApi {
         }
         br.close();
         return sb;
+    }
+
+    /**
+     * Set default SSL context for HTTPS connections.
+     *
+     * This is necessary when client has to use keystore
+     * (eg provide certification for client authentication).
+     *
+     * Use case: enterprise proxy requiring HTTPS client authentication
+     *
+     * @throws NoSuchAlgorithmException
+     */
+    private static void setDefaultSSLContext() throws NoSuchAlgorithmException {
+        HttpsURLConnection.setDefaultSSLSocketFactory(SSLContext.getDefault().getSocketFactory());
     }
 }

--- a/src/main/java/uk/gov/service/notify/NotificationList.java
+++ b/src/main/java/uk/gov/service/notify/NotificationList.java
@@ -50,4 +50,20 @@ public class NotificationList {
             notifications.add(new Notification(notification));
         }
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        StringBuilder notifications_string = new StringBuilder("\n");
+        for (Notification notification : notifications){
+            notifications_string.append(notification.toString()).append("\n");
+        }
+        return "NotificationList{" +
+                "notifications=" + notifications_string.toString() +
+                ", nextPageLink='" + nextPageLink + '\'' +
+                ", lastPageLink='" + lastPageLink + '\'' +
+                ", pageSize=" + pageSize +
+                ", total=" + total +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/service/notify/NotificationResponse.java
+++ b/src/main/java/uk/gov/service/notify/NotificationResponse.java
@@ -26,4 +26,13 @@ public class NotificationResponse {
     public int getTemplateVersion() {
         return templateVersion;
     }
+
+    @Override
+    public String toString() {
+        return "NotificationResponse{" +
+                "body='" + body + '\'' +
+                ", notificationId='" + notificationId + '\'' +
+                ", templateVersion=" + templateVersion +
+                '}';
+    }
 }


### PR DESCRIPTION
- 	Add the default SSL context for the NotificationClient.
The SSL context allows the client to be used with a keystore to provide certification for the client authentication.
This client can be used with an enterprise proxy requiring HTTPS client authentication.

- 	Added toString methods to response objects to make it easier to print out the responses in the TestNotificationClient