### PR TITLE
Integration tests

### DIFF
--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -42,8 +42,13 @@ public class ClientIntegrationTestIT {
         assertNotNull(notificationList.getNextPageLink());
         assertNotNull(notificationList.getNotifications());
         assertFalse(notificationList.getNotifications().isEmpty());
-        Notification firstNotification = notificationList.getNotifications().get(0);
-        assertNotification(firstNotification);
+        // get first notification that is in sending or delivered as because it is possible that the first notification is in created status, and the null checks will fail.
+        for(Notification notification : notificationList.getNotifications()){
+            if(Arrays.asList("sending", "delivered").contains(notification.getStatus())){
+                assertNotification(notification);
+                break;
+            }
+        }
     }
 
     private NotificationClient getClient(){


### PR DESCRIPTION
Added a check that the notification that is checked in the getAllNotifications test is in a status of sending or delivered.

This is because the test needs a notification in sending or delivered so that sent_by and sent_at are not null.