### PR TITLE
Update version and deploy java client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 environment.sh
 docker.env
+pom.xml.versionsBackup

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>2.1.7-RELEASE</version>
+        <version>2.1.8-RELEASE</version>
     </dependency>
 
 ```
@@ -58,7 +58,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:2.1.7-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:2.1.8-RELEASE')
 }
 ```
 

--- a/README.md-tpl
+++ b/README.md-tpl
@@ -1,0 +1,141 @@
+# GOV.UK Notify Java client
+
+## Installation
+
+### Maven
+
+The notifications-java-client is deployed to [Bintray](https://bintray.com/gov-uk-notify/maven/notifications-java-client). Add this snippet to your Maven `settings.xml` file.
+```xml
+<?xml version='1.0' encoding='UTF-8'?>
+<settings xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd' xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+<profiles>
+	<profile>
+		<repositories>
+			<repository>
+				<snapshots>
+					<enabled>false</enabled>
+				</snapshots>
+				<id>bintray-gov-uk-notify-maven</id>
+				<name>bintray</name>
+				<url>http://dl.bintray.com/gov-uk-notify/maven</url>
+			</repository>
+		</repositories>
+		<pluginRepositories>
+			<pluginRepository>
+				<snapshots>
+					<enabled>false</enabled>
+				</snapshots>
+				<id>bintray-gov-uk-notify-maven</id>
+				<name>bintray-plugins</name>
+				<url>http://dl.bintray.com/gov-uk-notify/maven</url>
+			</pluginRepository>
+		</pluginRepositories>
+		<id>bintray</id>
+	</profile>
+</profiles>
+<activeProfiles>
+	<activeProfile>bintray</activeProfile>
+</activeProfiles>
+</settings>
+```
+Then add the Maven dependency to your project.
+```xml
+    <dependency>
+        <groupId>uk.gov.service.notify</groupId>
+        <artifactId>notifications-java-client</artifactId>
+        <version>{version}</version>
+    </dependency>
+
+```
+
+### Gradle
+```
+repositories {
+    mavenCentral()
+    maven {
+        url  "http://dl.bintray.com/gov-uk-notify/maven"
+    }
+}
+
+dependencies {
+    compile('uk.gov.service.notify:notifications-java-client:{version}')
+}
+```
+
+### Artifactory or Nexus
+
+Click 'set me up!' on https://bintray.com/gov-uk-notify/maven/notifications-java-client for instructions.
+
+## Getting started
+
+
+```java
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.Notification;
+import uk.gov.service.notify.NotificationList;
+import uk.gov.service.notify.NotificationResponse;
+
+NotificationClient client = new NotificationClient(api_key, serviceId, "https://api.notifications.service.gov.uk");
+```
+
+Generate an API key by signing in to
+[GOV.UK Notify](https://www.notifications.service.gov.uk) and going to
+the **API integration** page.
+
+You'll find your service ID on the **API integration** page.
+
+## Send a message
+
+Text message:
+
+```java
+NotificationResponse response = client.sendSms(templateId, mobileNumber, null);
+```
+
+Email:
+
+```java
+NotificationResponse response = client.sendEmail(templateId, emailAddress, null);
+```
+
+Find `templateId` by clicking **API info** for the template you want to send.
+
+If a template has placeholders, you need to provide their values in `personalisation`, for example:
+
+```java
+HashMap<String, String> personalisation = new HashMap<>();
+personalisation.put("name", "Jo");
+personalisation.put("reference_number", "13566");
+NotificationResponse response = client.sendEmail(emailTemplateId,
+        emailAddress, personalisation);
+```
+
+## Get the status of one message
+
+```java
+Notification notification = client.getNotificationById(notificationId);
+```
+ 
+## Get the status of all messages
+
+```java
+Notification notification = client.getNotification(status, notificationType);
+```
+
+Optional `status` can be one of:
+
+* `null` (returns all messages)
+* `sending`
+* `delivered`
+* `permanent-failure`
+* `temporary-failure`
+* `technical-failure`
+
+Optional `notificationType` can be one of:
+
+* `null` (returns all messages)
+* `email`
+* `sms`
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>2.1.7-RELEASE</version>
+    <version>2.1.8-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/update_version_and_deploy.sh
+++ b/update_version_and_deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+
+read -p "What is the next release number: " version
+
+echo $version
+
+sed -e "s/{version}/${version}/" README.md-tpl > README.md
+
+mvn versions:set -DnewVersion=${version}
+
+source environment.sh
+
+mvn deploy


### PR DESCRIPTION
Created a script to update the version in the pom file and replace the version number in the readme.md then deploy that version to bintray.

You will need the bintray settings in the .m2/setting.xml file in order to deploy, however the updating of the version will still work.

From now on updates to the README should be done in the README.md-tpl. The template file contains the version variable that is replaced in the script.