### PR TITLE
New overloaded method signature for sendSms and sendEmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ You'll find your service ID on the **API integration** page.
 Text message:
 
 ```java
-NotificationResponse response = client.sendSms(templateId, mobileNumber, null);
+NotificationResponse response = client.sendSms(templateId, mobileNumber);
 ```
 
 Email:
 
 ```java
-NotificationResponse response = client.sendEmail(templateId, emailAddress, null);
+NotificationResponse response = client.sendEmail(templateId, emailAddress);
 ```
 
 Find `templateId` by clicking **API info** for the template you want to send.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Notification notification = client.getNotification(status, notificationType);
 Optional `status` can be one of:
 
 * `null` (returns all messages)
+* `created`
 * `sending`
 * `delivered`
 * `permanent-failure`

--- a/README.md-tpl
+++ b/README.md-tpl
@@ -89,13 +89,13 @@ You'll find your service ID on the **API integration** page.
 Text message:
 
 ```java
-NotificationResponse response = client.sendSms(templateId, mobileNumber, null);
+NotificationResponse response = client.sendSms(templateId, mobileNumber);
 ```
 
 Email:
 
 ```java
-NotificationResponse response = client.sendEmail(templateId, emailAddress, null);
+NotificationResponse response = client.sendEmail(templateId, emailAddress);
 ```
 
 Find `templateId` by clicking **API info** for the template you want to send.

--- a/README.md-tpl
+++ b/README.md-tpl
@@ -125,6 +125,7 @@ Notification notification = client.getNotification(status, notificationType);
 Optional `status` can be one of:
 
 * `null` (returns all messages)
+* `created`
 * `sending`
 * `delivered`
 * `permanent-failure`

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -53,6 +53,18 @@ public class NotificationClient implements NotificationClientApi {
     }
 
     /**
+     * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param templateId Find templateId by clicking API info for the template you want to send
+     * @param to The email address
+     * @return <code>NotificationResponse</code>
+     * @throws NotificationClientException
+     */
+    public NotificationResponse sendEmail(String templateId, String to) throws NotificationClientException {
+        return postRequest("email", templateId, to, null);
+    }
+
+    /**
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
      * @param templateId Find templateId by clicking API info for the template you want to send
@@ -63,6 +75,18 @@ public class NotificationClient implements NotificationClientApi {
      */
     public NotificationResponse sendSms(String templateId, String to, HashMap<String, String> personalisation) throws NotificationClientException {
         return postRequest("sms", templateId, to, personalisation);
+    }
+
+    /**
+     * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param templateId Find templateId by clicking API info for the template you want to send
+     * @param to The mobile phone number
+     * @return <code>NotificationResponse</code>
+     * @throws NotificationClientException
+     */
+    public NotificationResponse sendSms(String templateId, String to) throws NotificationClientException {
+        return postRequest("sms", templateId, to, null);
     }
 
     private NotificationResponse postRequest(String messageType, String templateId, String to, HashMap<String, String> personalisation) throws NotificationClientException {

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -44,7 +44,7 @@ public class NotificationClient implements NotificationClientApi {
      *
      * @param templateId Find templateId by clicking API info for the template you want to send
      * @param to The email address
-     * @param personalisation Optional HashMap representing the placeholders for the template if any. For example, key=name value=Bob
+     * @param personalisation HashMap representing the placeholders for the template if any. For example, key=name value=Bob
      * @return <code>NotificationResponse</code>
      * @throws NotificationClientException
      */
@@ -69,7 +69,7 @@ public class NotificationClient implements NotificationClientApi {
      *
      * @param templateId Find templateId by clicking API info for the template you want to send
      * @param to The mobile phone number
-     * @param personalisation Optional HashMap representing the placeholders for the template if any. For example, key=name value=Bob
+     * @param personalisation HashMap representing the placeholders for the template if any. For example, key=name value=Bob
      * @return <code>NotificationResponse</code>
      * @throws NotificationClientException
      */

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -17,6 +17,16 @@ public interface NotificationClientApi {
     NotificationResponse sendEmail(String templateId, String to, HashMap<String, String> personalisation) throws NotificationClientException;
 
     /**
+     * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param templateId Find templateId by clicking API info for the template you want to send
+     * @param to The email address
+     * @return <code>NotificationResponse</code>
+     * @throws NotificationClientException
+     */
+    NotificationResponse sendEmail(String templateId, String to) throws NotificationClientException;
+
+    /**
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
      * @param templateId Find templateId by clicking API info for the template you want to send
@@ -26,6 +36,16 @@ public interface NotificationClientApi {
      * @throws NotificationClientException
      */
     NotificationResponse sendSms(String templateId, String to, HashMap<String, String> personalisation) throws NotificationClientException;
+
+    /**
+     * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param templateId Find templateId by clicking API info for the template you want to send
+     * @param to The mobile phone number
+     * @return <code>NotificationResponse</code>
+     * @throws NotificationClientException
+     */
+    NotificationResponse sendSms(String templateId, String to) throws NotificationClientException;
 
     /**
      * The getNotificationById method will return a <code>Notification</code> for a given notification id.

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -10,7 +10,7 @@ public interface NotificationClientApi {
      *
      * @param templateId Find templateId by clicking API info for the template you want to send
      * @param to The email address
-     * @param personalisation Optional HashMap representing the placeholders for the template if any. For example, key=name value=Bob
+     * @param personalisation HashMap representing the placeholders for the template if any. For example, key=name value=Bob
      * @return <code>NotificationResponse</code>
      * @throws NotificationClientException
      */
@@ -31,7 +31,7 @@ public interface NotificationClientApi {
      *
      * @param templateId Find templateId by clicking API info for the template you want to send
      * @param to The mobile phone number
-     * @param personalisation Optional HashMap representing the placeholders for the template if any. For example, key=name value=Bob
+     * @param personalisation HashMap representing the placeholders for the template if any. For example, key=name value=Bob
      * @return <code>NotificationResponse</code>
      * @throws NotificationClientException
      */

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -51,6 +51,30 @@ public class ClientIntegrationTestIT {
         }
     }
 
+    @Test
+    public void testEmailNotificationWithoutPersonalisationReturnsErrorMessageIT() {
+        NotificationClient client = getClient();
+        try {
+            client.sendEmail(System.getenv("EMAIL_TEMPLATE_ID"), System.getenv("FUNCTIONAL_TEST_EMAIL"));
+            fail("Expected NotificationClientException: Missing personalisation: name");
+        } catch (NotificationClientException e) {
+            assert(e.getMessage().contains("Missing personalisation: name"));
+            assert(e.getMessage().contains("Status code: 400"));
+        }
+    }
+
+    @Test
+    public void testSmsNotificationWithoutPersonalisationReturnsErrorMessageIT() {
+        NotificationClient client = getClient();
+        try {
+            client.sendSms(System.getenv("SMS_TEMPLATE_ID"), System.getenv("FUNCTIONAL_TEST_NUMBER"));
+            fail("Expected NotificationClientException: Missing personalisation: name");
+        } catch (NotificationClientException e) {
+            assert(e.getMessage().contains("Missing personalisation: name"));
+            assert(e.getMessage().contains("Status code: 400"));
+        }
+    }
+
     private NotificationClient getClient(){
         String serviceId = System.getenv("SERVICE_ID");
         String apiKey = System.getenv("API_KEY");

--- a/update_version_and_deploy.sh
+++ b/update_version_and_deploy.sh
@@ -13,4 +13,4 @@ mvn versions:set -DnewVersion=${version}
 
 source environment.sh
 
-#mvn deploy
+mvn deploy

--- a/update_version_and_deploy.sh
+++ b/update_version_and_deploy.sh
@@ -13,4 +13,4 @@ mvn versions:set -DnewVersion=${version}
 
 source environment.sh
 
-mvn deploy
+#mvn deploy


### PR DESCRIPTION
- Added an overloaded method signature for sendSms and sendEmail that excludes the personalisation
- New functional tests that test sendSms and sendEmail without the personalisation for a template that requires personalisation.
  - the expected result is a NotificationClientException with a message of Missing personalisation.
- Updated the documentation to reflect this change.
- Feedback from user research shows that it is confusing to send null into a method in the documentation.