### PR TITLE
Make API key include secret and service ID

### DIFF
--- a/src/main/java/TestNotificationClient.java
+++ b/src/main/java/TestNotificationClient.java
@@ -12,12 +12,30 @@ import java.util.HashMap;
 public class TestNotificationClient {
 
     /**
-     * Args: api key, service id, baseUrl
+     * A command line tool to test the integration of the NotificationClient
+     * Run by using this command:
+     * mvn exec:java -Dexec.mainClass=TestNotificationClient -Dexec.args="api_key service_ID https://api.notifications.service.gov.uk"
+     * OR
+     * mvn exec:java -Dexec.mainClass=TestNotificationClient -Dexec.args="single_api_key https://api.notifications.service.gov.uk"
+     *    where single_api_key = api key name + service id + api key
+     * Args: either enter 3 arguments: api key, service id, baseUrl
+     *      or 2: api key, baseUrl (single api key that is the api key name + service id + api key)
+     *
      * @param args
      * @throws Exception
      */
     public static void main(String[] args) throws Exception {
-        NotificationClient client = new NotificationClient(args[0], args[1], args[2]);
+        NotificationClient client = null;
+        if(args.length == 2) {
+            client = new NotificationClient(args[0], args[1]);
+        }
+        if(args.length == 3) {
+            client = new NotificationClient(args[0], args[1], args[2]);
+        }
+        else{
+            System.out.println("expected either 2 or 3 arguments  got: " + args.length);
+            System.exit(1);
+        }
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
         System.out.println("Select an option from the following options: \n 1 - create \n 2 - fetch \n 3 - fetch-all");
         String requestType = reader.readLine();

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -29,33 +29,32 @@ public class NotificationClient implements NotificationClientApi {
 
     public NotificationClient(String apiKey, String baseUrl) {
         this(
-                apiKey.substring(Math.max(0, apiKey.length() - 36)),
-                apiKey.substring(
-                        Math.max(0, apiKey.length() - 73),
-                        Math.max(0, apiKey.length() - 37)
-                ),
+                extractApiKey(apiKey),
+                extractServiceId(apiKey),
                 baseUrl
         );
     }
 
     public NotificationClient(String apiKey, String baseUrl, Proxy proxy) {
         this(
-          apiKey.substring(Math.max(0, apiKey.length() - 36)),
-          apiKey.substring(
-            Math.max(0, apiKey.length() - 73),
-            Math.max(0, apiKey.length() - 37)
-          ),
-          baseUrl,
-          proxy
+                extractApiKey(apiKey),
+                extractServiceId(apiKey),
+                baseUrl,
+                proxy
         );
     }
 
     public NotificationClient(String apiKey, String serviceId, String baseUrl) {
-        this(apiKey, serviceId, baseUrl, null);
+        this(
+                apiKey,
+                serviceId,
+                baseUrl,
+                null
+        );
     }
 
     public NotificationClient(String apiKey, String serviceId, String baseUrl, Proxy proxy) {
-        this.apiKey = apiKey.substring(Math.max(0, apiKey.length() - 36));
+        this.apiKey = extractApiKey(apiKey);
         this.serviceId = serviceId;
         this.baseUrl = baseUrl;
         this.proxy = proxy;
@@ -78,15 +77,15 @@ public class NotificationClient implements NotificationClientApi {
         return baseUrl;
     }
 
-    public Proxy getProxy(){
+    public Proxy getProxy() {
         return proxy;
     }
 
     /**
      * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
-     * @param templateId Find templateId by clicking API info for the template you want to send
-     * @param to The email address
+     * @param templateId      Find templateId by clicking API info for the template you want to send
+     * @param to              The email address
      * @param personalisation HashMap representing the placeholders for the template if any. For example, key=name value=Bob
      * @return <code>NotificationResponse</code>
      * @throws NotificationClientException
@@ -99,7 +98,7 @@ public class NotificationClient implements NotificationClientApi {
      * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
      * @param templateId Find templateId by clicking API info for the template you want to send
-     * @param to The email address
+     * @param to         The email address
      * @return <code>NotificationResponse</code>
      * @throws NotificationClientException
      */
@@ -110,8 +109,8 @@ public class NotificationClient implements NotificationClientApi {
     /**
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
-     * @param templateId Find templateId by clicking API info for the template you want to send
-     * @param to The mobile phone number
+     * @param templateId      Find templateId by clicking API info for the template you want to send
+     * @param to              The mobile phone number
      * @param personalisation HashMap representing the placeholders for the template if any. For example, key=name value=Bob
      * @return <code>NotificationResponse</code>
      * @throws NotificationClientException
@@ -124,7 +123,7 @@ public class NotificationClient implements NotificationClientApi {
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
      * @param templateId Find templateId by clicking API info for the template you want to send
-     * @param to The mobile phone number
+     * @param to         The mobile phone number
      * @return <code>NotificationResponse</code>
      * @throws NotificationClientException
      */
@@ -207,8 +206,8 @@ public class NotificationClient implements NotificationClientApi {
     /**
      * The getNotifications method will create a GET HTTPS request to retrieve all the notifications.
      *
-     * @param status If status is not null notifications will only return notifications for the given status.
-     *               Possible statuses are created|sending|delivered|permanent-failure|temporary-failure|technical-failure
+     * @param status            If status is not null notifications will only return notifications for the given status.
+     *                          Possible statuses are created|sending|delivered|permanent-failure|temporary-failure|technical-failure
      * @param notification_type If notification_type is not null only notification of the given status will be returned.
      *                          Possible notificationTypes are sms|email
      * @return <code>NotificationList</code>
@@ -297,15 +296,23 @@ public class NotificationClient implements NotificationClientApi {
 
     /**
      * Set default SSL context for HTTPS connections.
-     *
+     * <p/>
      * This is necessary when client has to use keystore
      * (eg provide certification for client authentication).
-     *
+     * <p/>
      * Use case: enterprise proxy requiring HTTPS client authentication
      *
      * @throws NoSuchAlgorithmException
      */
     private static void setDefaultSSLContext() throws NoSuchAlgorithmException {
         HttpsURLConnection.setDefaultSSLSocketFactory(SSLContext.getDefault().getSocketFactory());
+    }
+
+    private static String extractServiceId(String apiKey) {
+        return apiKey.substring(Math.max(0, apiKey.length() - 73), Math.max(0, apiKey.length() - 37));
+    }
+
+    private static String extractApiKey(String apiKey) {
+        return apiKey.substring(Math.max(0, apiKey.length() - 36));
     }
 }

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -48,11 +48,6 @@ public class NotificationClient implements NotificationClientApi {
 
     public NotificationClient(String apiKey, String serviceId, String baseUrl) {
         this(apiKey, serviceId, baseUrl, null);
-        try {
-            setDefaultSSLContext();
-        } catch (NoSuchAlgorithmException e) {
-            LOGGER.log(Level.SEVERE, e.toString(), e);
-        }
     }
 
     public NotificationClient(String apiKey, String serviceId, String baseUrl, Proxy proxy) {
@@ -60,6 +55,11 @@ public class NotificationClient implements NotificationClientApi {
         this.serviceId = serviceId;
         this.baseUrl = baseUrl;
         this.proxy = proxy;
+        try {
+            setDefaultSSLContext();
+        } catch (NoSuchAlgorithmException e) {
+            LOGGER.log(Level.SEVERE, e.toString(), e);
+        }
     }
 
     public String getApiKey() {

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -23,6 +23,27 @@ public class NotificationClient implements NotificationClientApi {
     private final String baseUrl;
     private final Proxy proxy;
 
+    public NotificationClient(String apiKey) {
+        this(apiKey, null);
+        try {
+            setDefaultSSLContext();
+        } catch (NoSuchAlgorithmException e) {
+            LOGGER.log(Level.SEVERE, e.toString(), e);
+        }
+    }
+
+    public NotificationClient(String apiKey, Proxy proxy) {
+        this(
+          apiKey.substring(Math.max(0, apiKey.length() - 36)),
+          apiKey.substring(
+            Math.max(0, apiKey.length() - 74),
+            Math.max(0, apiKey.length() - 37)
+          ),
+          "https://api.notifications.service.gov.uk",
+          proxy
+        );
+    }
+
     public NotificationClient(String apiKey, String serviceId, String baseUrl) {
         this(apiKey, serviceId, baseUrl, null);
         try {

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -62,6 +62,22 @@ public class NotificationClient implements NotificationClientApi {
         this.proxy = proxy;
     }
 
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public Proxy getProxy(){
+        return proxy;
+    }
+
     /**
      * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -23,6 +23,10 @@ public class NotificationClient implements NotificationClientApi {
     private final String baseUrl;
     private final Proxy proxy;
 
+    public NotificationClient(String apiKey) {
+        this(apiKey, "https://api.notifications.service.gov.uk");
+    }
+
     public NotificationClient(String apiKey, String baseUrl) {
         this(
                 apiKey.substring(Math.max(0, apiKey.length() - 36)),

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -23,23 +23,25 @@ public class NotificationClient implements NotificationClientApi {
     private final String baseUrl;
     private final Proxy proxy;
 
-    public NotificationClient(String apiKey) {
-        this(apiKey, null);
-        try {
-            setDefaultSSLContext();
-        } catch (NoSuchAlgorithmException e) {
-            LOGGER.log(Level.SEVERE, e.toString(), e);
-        }
+    public NotificationClient(String apiKey, String baseUrl) {
+        this(
+                apiKey.substring(Math.max(0, apiKey.length() - 36)),
+                apiKey.substring(
+                        Math.max(0, apiKey.length() - 73),
+                        Math.max(0, apiKey.length() - 37)
+                ),
+                baseUrl
+        );
     }
 
-    public NotificationClient(String apiKey, Proxy proxy) {
+    public NotificationClient(String apiKey, String baseUrl, Proxy proxy) {
         this(
           apiKey.substring(Math.max(0, apiKey.length() - 36)),
           apiKey.substring(
-            Math.max(0, apiKey.length() - 74),
+            Math.max(0, apiKey.length() - 73),
             Math.max(0, apiKey.length() - 37)
           ),
-          "https://api.notifications.service.gov.uk",
+          baseUrl,
           proxy
         );
     }

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -33,7 +33,7 @@ public class NotificationClient implements NotificationClientApi {
     }
 
     public NotificationClient(String apiKey, String serviceId, String baseUrl, Proxy proxy) {
-        this.apiKey = apiKey;
+        this.apiKey = apiKey.substring(Math.max(0, apiKey.length() - 36));
         this.serviceId = serviceId;
         this.baseUrl = baseUrl;
         this.proxy = proxy;

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -18,7 +18,7 @@ public class ClientIntegrationTestIT {
 
     @Test
     public void testEmailNotificationIT() throws NotificationClientException, InterruptedException {
-        NotificationClient client = getNewClient();
+        NotificationClient client = getClient();
         NotificationResponse emailResponse = sendEmail(client);
         Notification notification = getNotificationByIdWithStatusGreaterThanCreated(client, emailResponse);
         assertNotification(notification);
@@ -73,20 +73,6 @@ public class ClientIntegrationTestIT {
             assert(e.getMessage().contains("Missing personalisation: name"));
             assert(e.getMessage().contains("Status code: 400"));
         }
-    }
-
-    private NotificationClient getNewClient(){
-        String serviceId = System.getenv("SERVICE_ID");
-        String apiKey = System.getenv("API_KEY");
-        String baseUrl = System.getenv("NOTIFY_API_URL");
-        String keyName = System.getenv("API_KEY_NAME");
-        StringBuffer sb = new StringBuffer();
-        sb.append(keyName);
-        sb.append("-");
-        sb.append(serviceId);
-        sb.append("-").append(apiKey);
-        NotificationClient client = new NotificationClient(sb.toString(), baseUrl);
-        return client;
     }
 
     private NotificationClient getClient(){

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -18,7 +18,7 @@ public class ClientIntegrationTestIT {
 
     @Test
     public void testEmailNotificationIT() throws NotificationClientException, InterruptedException {
-        NotificationClient client = getClient();
+        NotificationClient client = getNewClient();
         NotificationResponse emailResponse = sendEmail(client);
         Notification notification = getNotificationByIdWithStatusGreaterThanCreated(client, emailResponse);
         assertNotification(notification);
@@ -73,6 +73,20 @@ public class ClientIntegrationTestIT {
             assert(e.getMessage().contains("Missing personalisation: name"));
             assert(e.getMessage().contains("Status code: 400"));
         }
+    }
+
+    private NotificationClient getNewClient(){
+        String serviceId = System.getenv("SERVICE_ID");
+        String apiKey = System.getenv("API_KEY");
+        String baseUrl = System.getenv("NOTIFY_API_URL");
+        String keyName = System.getenv("API_KEY_NAME");
+        StringBuffer sb = new StringBuffer();
+        sb.append(keyName);
+        sb.append("-");
+        sb.append(serviceId);
+        sb.append("-").append(apiKey);
+        NotificationClient client = new NotificationClient(sb.toString(), baseUrl);
+        return client;
     }
 
     private NotificationClient getClient(){

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -12,10 +12,10 @@ import static org.junit.Assert.assertNull;
 public class NotificationClientTest {
     private final String apiKey = UUID.randomUUID().toString();
     private final String serviceId = UUID.randomUUID().toString();
-    private final String baseUrl = "https://notifications.service.gov.uk";
+    private final String baseUrl = "https://api.notifications.service.gov.uk";
 
     @Test
-    public void testCreateNotificationClient_withSingleApiKey(){
+    public void testCreateNotificationClient_withSingleApiKeyAndBaseUrl(){
         String singleApiKey = "Api key name -" + serviceId + "-" + apiKey;
 
         NotificationClient client = new NotificationClient(singleApiKey, baseUrl);
@@ -43,6 +43,15 @@ public class NotificationClientTest {
         NotificationClient client = new NotificationClient(apiKey, serviceId, baseUrl, proxy);
         assertNotificationWithProxy(proxy, client);
     }
+
+    @Test
+    public void testCreateNotificationClient_withSingleApiKey() {
+        String singleApiKey = "Api key name -" + serviceId + "-" + apiKey;
+        NotificationClient client = new NotificationClient(singleApiKey);
+        assertNotificationClient(client);
+    }
+
+
     private void assertNotificationWithProxy(Proxy proxy, NotificationClient client) {
         assertEquals(client.getApiKey(), apiKey);
         assertEquals(client.getServiceId(), serviceId);

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -1,0 +1,59 @@
+package uk.gov.service.notify;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class NotificationClientTest {
+    private final String apiKey = UUID.randomUUID().toString();
+    private final String serviceId = UUID.randomUUID().toString();
+    private final String baseUrl = "https://notifications.service.gov.uk";
+
+    @Test
+    public void testCreateNotificationClient_withSingleApiKey(){
+        String singleApiKey = "Api key name -" + serviceId + "-" + apiKey;
+
+        NotificationClient client = new NotificationClient(singleApiKey, baseUrl);
+        assertNotificationClient(client);
+
+    }
+
+    @Test
+    public void testCreateNotificationClient_withApiKeyServiceId(){
+        NotificationClient client = new NotificationClient(apiKey, serviceId, baseUrl);
+        assertNotificationClient(client);
+    }
+
+    @Test
+    public void testCreateNotificationClient_withSingleApiKeyAndProxy() {
+        String singleApiKey = "Api key name -" + serviceId + "-" + apiKey;
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("10.0.0.1", 8080));
+        NotificationClient client = new NotificationClient(singleApiKey, baseUrl, proxy);
+        assertNotificationWithProxy(proxy, client);
+    }
+
+    @Test
+    public void testCreateNotificationClient_withSingleApiKeyServiceIdAndProxy() {
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("10.0.0.1", 8080));
+        NotificationClient client = new NotificationClient(apiKey, serviceId, baseUrl, proxy);
+        assertNotificationWithProxy(proxy, client);
+    }
+    private void assertNotificationWithProxy(Proxy proxy, NotificationClient client) {
+        assertEquals(client.getApiKey(), apiKey);
+        assertEquals(client.getServiceId(), serviceId);
+        assertEquals(client.getBaseUrl(), baseUrl);
+        assertEquals(client.getProxy(), proxy);
+    }
+
+    private void assertNotificationClient(final NotificationClient client){
+        assertEquals(client.getApiKey(), apiKey);
+        assertEquals(client.getServiceId(), serviceId);
+        assertEquals(client.getBaseUrl(), baseUrl);
+        assertNull(client.getProxy());
+    }
+}


### PR DESCRIPTION
In research we’ve seen people mix up the service ID and API key because they’re both 36 character UUIDs. We can’t get rid of the service ID because it’s used to look up the API key.

Instead, we should change API key to be one long string, which contains both the service ID, API key and (optionally) the name of the key. For example:

**API key**
```
casework_production-8b3aa916-ec82-434e-b0c5-d5d9b371d6a3-dcdc5083-2fee-4fba-8afd-51f3f4bcb7b0
```

This commit changes the client to make the service ID optional. If it’s not passed, they we attempt to extract it from the secret instead.

***

We also need to make sure that someone can use a service ID _and_ the new format of API key (see next commit). If someone makes a new API key they’ll get it in the new format, but might not want to update their client.

The API key is always the last part of the string, so let’s ignore anything before the last 36 characters.