### PR TITLE
Instantiate client with combined API key in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>2.1.8-RELEASE</version>
+        <version>2.2.0-RELEASE</version>
     </dependency>
 
 ```
@@ -58,7 +58,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:2.1.8-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:2.2.0-RELEASE')
 }
 ```
 
@@ -75,14 +75,12 @@ import uk.gov.service.notify.Notification;
 import uk.gov.service.notify.NotificationList;
 import uk.gov.service.notify.NotificationResponse;
 
-NotificationClient client = new NotificationClient(api_key, serviceId, "https://api.notifications.service.gov.uk");
+NotificationClient client = new NotificationClient(apiKey);
 ```
 
 Generate an API key by signing in to
 [GOV.UK Notify](https://www.notifications.service.gov.uk) and going to
 the **API integration** page.
-
-You'll find your service ID on the **API integration** page.
 
 ## Send a message
 

--- a/README.md-tpl
+++ b/README.md-tpl
@@ -75,14 +75,12 @@ import uk.gov.service.notify.Notification;
 import uk.gov.service.notify.NotificationList;
 import uk.gov.service.notify.NotificationResponse;
 
-NotificationClient client = new NotificationClient(api_key, serviceId, "https://api.notifications.service.gov.uk");
+NotificationClient client = new NotificationClient(api_key);
 ```
 
 Generate an API key by signing in to
 [GOV.UK Notify](https://www.notifications.service.gov.uk) and going to
 the **API integration** page.
-
-You'll find your service ID on the **API integration** page.
 
 ## Send a message
 

--- a/README.md-tpl
+++ b/README.md-tpl
@@ -75,7 +75,7 @@ import uk.gov.service.notify.Notification;
 import uk.gov.service.notify.NotificationList;
 import uk.gov.service.notify.NotificationResponse;
 
-NotificationClient client = new NotificationClient(api_key);
+NotificationClient client = new NotificationClient(apiKey);
 ```
 
 Generate an API key by signing in to

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+source environment.sh
+
+mvn deploy

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>2.1.8-RELEASE</version>
+    <version>2.2.0-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/update_version.sh
+++ b/update_version.sh
@@ -10,7 +10,3 @@ echo $version
 sed -e "s/{version}/${version}/" README.md-tpl > README.md
 
 mvn versions:set -DnewVersion=${version}
-
-source environment.sh
-
-mvn deploy


### PR DESCRIPTION
So that users don’t have to worry about:
- base URL
- service ID

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/968