### PR TITLE
Fix integration tests

### DIFF
--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -38,8 +38,6 @@ public class ClientIntegrationTestIT {
         NotificationList notificationList = client.getNotifications(null, null);
         assertNotNull(notificationList);
         assertNotNull(notificationList.getTotal());
-        assertNotNull(notificationList.getLastPageLink());
-        assertNotNull(notificationList.getNextPageLink());
         assertNotNull(notificationList.getNotifications());
         assertFalse(notificationList.getNotifications().isEmpty());
         // get first notification that is in sending or delivered as because it is possible that the first notification is in created status, and the null checks will fail.


### PR DESCRIPTION
Removed the check that the next page and last page links are populated in the get all notifications integration test.

If the notification count is less than the page size the links could be null.