### PR TITLE
Add template methods to the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * `getTemplateById` - get the latest version of a template by id.
 * `getTemplateVersion` - get the template by id and version.
 * `getAllTemplates` - get all templates, can be filtered by template type.
-* `getTemplatePreview` - get the contents of a template with the placeholders replaced with the given personalisation.
+* `generateTemplatePreview` - get the contents of a template with the placeholders replaced with the given personalisation.
 * See the README for more information about the new template methods. 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.2.0-RELEASE
+* Template endpoints added to the NotificationsClient
+* `getTemplateById` - get the latest version of a template by id.
+* `getTemplateVersion` - get the template by id and version.
+* `getAllTemplates` - get all templates, can be filtered by template type.
+* `getTemplatePreview` - get the contents of a template with the placeholders replaced with the given personalisation.
+* See the README for more information about the new template methods. 
+
+
 ## 3.1.3-RELEASE
 
 ### Changed

--- a/README-tpl.md
+++ b/README-tpl.md
@@ -346,6 +346,7 @@ NotificationList notification = client.getNotifications(status, notificationType
 <summary>
 NotificationList
 </summary>
+
 If successful a `NotificationList` is returned. Below is a list of attributes in a`NotificationList`.
 ```java
     List<Notification> notifications;
@@ -430,6 +431,7 @@ Template template = client.getTemplateById(templateId);
 <summary>
 Response
 </summary>
+
 ```Java
     UUID id;
     String templateType;
@@ -491,6 +493,7 @@ Template template = client.getTemplateVersion(templateId, version);
 <summary>
 Response
 </summary>
+
 ```Java
     UUID id;
     String templateType;
@@ -555,6 +558,7 @@ TemplateList templates = client.getAllTemplates(templateType);
 <summary>
 Response
 </summary>
+
 ```java
     List<Template> templates;
 ```
@@ -588,6 +592,7 @@ TemplatePreview templatePreview = client.getTemplatePreview(templateId, personal
 <summary>
 Response
 </summary>
+
 ```java
     UUID id;
     String templateType;

--- a/README-tpl.md
+++ b/README-tpl.md
@@ -420,7 +420,7 @@ You can pass an empty string or null to ignore the filter
 
 
 ## Get a template by ID
-This will return the latest version of the template. Use get_template_version to retrieve a specific template version.
+This will return the latest version of the template. Use [getTemplateVersion](#get-a-template-by-id-and-version) to retrieve a specific template version.
 
 ```java
 Template template = client.getTemplateById(templateId);
@@ -472,3 +472,72 @@ Status code: 400 {
 </tbody>
 </table>
 </details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+
+## Get a template by ID and version
+This will return the template for the given id and version.
+
+```java
+Template template = client.getTemplateVersion(templateId, version);
+```
+
+<details>
+<summary>
+SendSmsResponse
+</summary>
+    private UUID id;
+    private String templateType;
+    private DateTime createdAt;
+    private DateTime updatedAt;
+    private String createdBy;
+    private int version;
+    private String body;
+    private String subject;
+</details>
+
+Otherwise the client will raise a `NotificationClientException`.
+
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+#### `version`
+A history of the template is kept. There is a link to `See previous versions` on the template page in the application.
+

--- a/README-tpl.md
+++ b/README-tpl.md
@@ -258,7 +258,7 @@ The email address the email notification is sent to.
 
 #### `templateId`
 
-Find by clicking **API info** for the template you want to send.
+The template id is visible on the template page in the application.
 
 #### `personalisation`
 If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
@@ -428,17 +428,18 @@ Template template = client.getTemplateById(templateId);
 
 <details>
 <summary>
-SendSmsResponse
+Response
 </summary>
-    private UUID id;
-    private String templateType;
-    private DateTime createdAt;
-    private DateTime updatedAt;
-    private String createdBy;
-    private int version;
-    private String body;
-    private String subject;
-</details>
+```Java
+    UUID id;
+    String templateType;
+    DateTime createdAt;
+    Optional<DateTime> updatedAt;
+    String createdBy;
+    int version;
+    String body;
+    Optional<String> subject;
+```
 
 Otherwise the client will raise a `NotificationClientException`.
 
@@ -488,17 +489,18 @@ Template template = client.getTemplateVersion(templateId, version);
 
 <details>
 <summary>
-SendSmsResponse
+Response
 </summary>
-    private UUID id;
-    private String templateType;
-    private DateTime createdAt;
-    private DateTime updatedAt;
-    private String createdBy;
-    private int version;
-    private String body;
-    private String subject;
-</details>
+```Java
+    UUID id;
+    String templateType;
+    DateTime createdAt;
+    Optional<DateTime> updatedAt;
+    String createdBy;
+    int version;
+    String body;
+    Optional<String> subject;
+```
 
 Otherwise the client will raise a `NotificationClientException`.
 
@@ -577,18 +579,21 @@ You can also pass in an empty string or null to ignore the filter.
 
 
 ## Generate a preview template
-If successful returns a template with the placeholders replaced with the given personalisation.
+This will return the contents of a template with the placeholders replaced with the given personalisation.
+```Java
+TemplatePreview templatePreview = client.getTemplatePreview(templateId, personalisation)
+```
 
 <details>
 <summary>
 Response
 </summary>
 ```java
-    private UUID id;
-    private String templateType;
-    private int version;
-    private String body;
-    private String subject;
+    UUID id;
+    String templateType;
+    int version;
+    String body;
+    Optional<String> subject;
 ```
 
 Otherwise a `NotificationClientException` is thrown.
@@ -623,3 +628,12 @@ Status code: 400 {
 </table>
 
 </details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+#### `personalisation`
+If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
+

--- a/README-tpl.md
+++ b/README-tpl.md
@@ -541,3 +541,36 @@ The template id is visible on the template page in the application.
 #### `version`
 A history of the template is kept. There is a link to `See previous versions` on the template page in the application.
 
+
+## Get all templates
+This will return the latest version of each template for your service.
+
+```java
+TemplateList templates = client.getAllTemplates(templateType);
+```
+
+<details>
+<summary>
+Response
+</summary>
+```java
+    List<Template> templates;
+```
+If the response is successful, a TemplateList is returned.
+  
+If no templates exist for a template type or there no templates for a service, the templates list will be empty.
+
+Otherwise the client will raise a `NotificationClientException`.
+
+
+</details>
+
+### Arguments
+
+#### `templateType`
+You can filter the templates by the following options:
+
+* `email`
+* `sms`
+* `letter`
+You can also pass in an empty string or null to ignore the filter.

--- a/README-tpl.md
+++ b/README-tpl.md
@@ -417,3 +417,58 @@ You can pass an empty string or null to ignore the filter.
 #### `olderThanId`
 You can get the notifications older than a given `Notification.notificationId`.
 You can pass an empty string or null to ignore the filter
+
+
+## Get a template by ID
+This will return the latest version of the template. Use get_template_version to retrieve a specific template version.
+
+```java
+Template template = client.getTemplateById(templateId);
+```
+
+<details>
+<summary>
+SendSmsResponse
+</summary>
+    private UUID id;
+    private String templateType;
+    private DateTime createdAt;
+    private DateTime updatedAt;
+    private String createdBy;
+    private int version;
+    private String body;
+    private String subject;
+</details>
+
+Otherwise the client will raise a `NotificationClientException`.
+
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+</details>

--- a/README-tpl.md
+++ b/README-tpl.md
@@ -574,3 +574,52 @@ You can filter the templates by the following options:
 * `sms`
 * `letter`
 You can also pass in an empty string or null to ignore the filter.
+
+
+## Generate a preview template
+If successful returns a template with the placeholders replaced with the given personalisation.
+
+<details>
+<summary>
+Response
+</summary>
+```java
+    private UUID id;
+    private String templateType;
+    private int version;
+    private String body;
+    private String subject;
+```
+
+Otherwise a `NotificationClientException` is thrown.
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+
+</details>

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ NotificationList notification = client.getNotifications(status, notificationType
 <summary>
 NotificationList
 </summary>
+
 If successful a `NotificationList` is returned. Below is a list of attributes in a`NotificationList`.
 ```java
     List<Notification> notifications;
@@ -430,6 +431,7 @@ Template template = client.getTemplateById(templateId);
 <summary>
 Response
 </summary>
+
 ```Java
     UUID id;
     String templateType;
@@ -491,6 +493,7 @@ Template template = client.getTemplateVersion(templateId, version);
 <summary>
 Response
 </summary>
+
 ```Java
     UUID id;
     String templateType;
@@ -555,6 +558,7 @@ TemplateList templates = client.getAllTemplates(templateType);
 <summary>
 Response
 </summary>
+
 ```java
     List<Template> templates;
 ```
@@ -588,6 +592,7 @@ TemplatePreview templatePreview = client.getTemplatePreview(templateId, personal
 <summary>
 Response
 </summary>
+
 ```java
     UUID id;
     String templateType;

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>3.1.3-RELEASE</version>
+        <version>3.2.0-RELEASE</version>
     </dependency>
 
 ```
@@ -58,7 +58,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:3.1.3-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:3.2.0-RELEASE')
 }
 ```
 
@@ -258,7 +258,7 @@ The email address the email notification is sent to.
 
 #### `templateId`
 
-Find by clicking **API info** for the template you want to send.
+The template id is visible on the template page in the application.
 
 #### `personalisation`
 If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
@@ -417,3 +417,223 @@ You can pass an empty string or null to ignore the filter.
 #### `olderThanId`
 You can get the notifications older than a given `Notification.notificationId`.
 You can pass an empty string or null to ignore the filter
+
+
+## Get a template by ID
+This will return the latest version of the template. Use [getTemplateVersion](#get-a-template-by-id-and-version) to retrieve a specific template version.
+
+```java
+Template template = client.getTemplateById(templateId);
+```
+
+<details>
+<summary>
+Response
+</summary>
+```Java
+    UUID id;
+    String templateType;
+    DateTime createdAt;
+    Optional<DateTime> updatedAt;
+    String createdBy;
+    int version;
+    String body;
+    Optional<String> subject;
+```
+
+Otherwise the client will raise a `NotificationClientException`.
+
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+
+## Get a template by ID and version
+This will return the template for the given id and version.
+
+```java
+Template template = client.getTemplateVersion(templateId, version);
+```
+
+<details>
+<summary>
+Response
+</summary>
+```Java
+    UUID id;
+    String templateType;
+    DateTime createdAt;
+    Optional<DateTime> updatedAt;
+    String createdBy;
+    int version;
+    String body;
+    Optional<String> subject;
+```
+
+Otherwise the client will raise a `NotificationClientException`.
+
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+#### `version`
+A history of the template is kept. There is a link to `See previous versions` on the template page in the application.
+
+
+## Get all templates
+This will return the latest version of each template for your service.
+
+```java
+TemplateList templates = client.getAllTemplates(templateType);
+```
+
+<details>
+<summary>
+Response
+</summary>
+```java
+    List<Template> templates;
+```
+If the response is successful, a TemplateList is returned.
+  
+If no templates exist for a template type or there no templates for a service, the templates list will be empty.
+
+Otherwise the client will raise a `NotificationClientException`.
+
+
+</details>
+
+### Arguments
+
+#### `templateType`
+You can filter the templates by the following options:
+
+* `email`
+* `sms`
+* `letter`
+You can also pass in an empty string or null to ignore the filter.
+
+
+## Generate a preview template
+This will return the contents of a template with the placeholders replaced with the given personalisation.
+```Java
+TemplatePreview templatePreview = client.getTemplatePreview(templateId, personalisation)
+```
+
+<details>
+<summary>
+Response
+</summary>
+```java
+    UUID id;
+    String templateType;
+    int version;
+    String body;
+    Optional<String> subject;
+```
+
+Otherwise a `NotificationClientException` is thrown.
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 404 {
+"errors":
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+}]
+}
+</pre>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "id is not a valid UUID"
+}]
+}
+</pre>
+</tbody>
+</table>
+
+</details>
+
+### Arguments
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+#### `personalisation`
+If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.1.3-RELEASE</version>
+    <version>3.2.0-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/uk/gov/service/notify/Notification.java
+++ b/src/main/java/uk/gov/service/notify/Notification.java
@@ -32,12 +32,10 @@ public class Notification {
     public Notification(String content){
         JSONObject responseBodyAsJson = new JSONObject(content);
         build(responseBodyAsJson);
-
     }
 
     public Notification(org.json.JSONObject data){
         build(data);
-
     }
 
     private void build(JSONObject data) {

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -268,7 +268,7 @@ public class NotificationClient implements NotificationClientApi {
     }
 
     /**
-     * The getTemplatePreview returns a template with the placeholders replaced with the given personalisation.
+     * The generateTemplatePreview returns a template with the placeholders replaced with the given personalisation.
      *
      * @param templateId The template id is visible from the template page in the application.
      * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
@@ -276,7 +276,7 @@ public class NotificationClient implements NotificationClientApi {
      * @return <code>TemplatePreview</code>
      * @throws NotificationClientException
      */
-    public TemplatePreview getTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException {
+    public TemplatePreview generateTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException {
         JSONObject body = new JSONObject();
         if (personalisation != null && !personalisation.isEmpty()) {
             body.put("personalisation", new JSONObject(personalisation));

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -218,12 +218,27 @@ public class NotificationClient implements NotificationClientApi {
     /**
      * The getTemplateById returns a <code>Template</code> given the template id.
      *
-     *
      * @param templateId The template id is visible from the template page in the application.
      * @return <code>Template</code>
      */
     public Template getTemplateById(String templateId) throws NotificationClientException{
         String url = baseUrl + "/v2/template/" + templateId;
+        HttpsURLConnection conn = createConnectionAndSetHeaders(url, "GET");
+        String response = performGetRequest(conn);
+        return new Template(response);
+    }
+
+    /**
+     * The getTemplateVersion returns a <code>Template</code> given the template id and version.
+     *
+     *
+     * @param templateId The template id is visible from the template page in the application.
+     * @param version The version of the template to return
+     * @return <code>Template</code>
+     * @throws NotificationClientException
+     */
+    public Template getTemplateVersion(String templateId, int version) throws NotificationClientException{
+        String url = baseUrl + "/v2/template/" + templateId + "/version/" + version;
         HttpsURLConnection conn = createConnectionAndSetHeaders(url, "GET");
         String response = performGetRequest(conn);
         return new Template(response);

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -103,7 +103,7 @@ public class NotificationClient implements NotificationClientApi {
     }
 
     public String getUserAgent() {
-      return "NOTIFY-API-JAVA-CLIENT/" + version;
+        return "NOTIFY-API-JAVA-CLIENT/" + version;
     }
 
     public String getApiKey() {
@@ -215,6 +215,20 @@ public class NotificationClient implements NotificationClientApi {
         }
     }
 
+    /**
+     * The getTemplateById returns a <code>Template</code> given the template id.
+     *
+     *
+     * @param templateId The template id is visible from the template page in the application.
+     * @return <code>Template</code>
+     */
+    public Template getTemplateById(String templateId) throws NotificationClientException{
+        String url = baseUrl + "/v2/template/" + templateId;
+        HttpsURLConnection conn = createConnectionAndSetHeaders(url, "GET");
+        String response = performGetRequest(conn);
+        return new Template(response);
+    }
+
     private String performPostRequest(HttpsURLConnection conn, JSONObject body) throws NotificationClientException {
         try{
             OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());
@@ -237,7 +251,7 @@ public class NotificationClient implements NotificationClientApi {
             if (conn != null) {
                 conn.disconnect();
             }
-    }
+        }
     }
 
     private String performGetRequest(HttpsURLConnection conn) throws NotificationClientException {

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -244,6 +244,29 @@ public class NotificationClient implements NotificationClientApi {
         return new Template(response);
     }
 
+    /**
+     * Returns all the templates for your service. Filtered by template type if not null.
+     *
+     * @param templateType If templateType is not empty or null templates will be filtered by type.
+     *          Possible template types are email|sms|letter
+     * @return <code>TemplateList</code>
+     * @throws NotificationClientException
+     */
+    public TemplateList getAllTemplates(String templateType) throws NotificationClientException{
+        try{
+            URIBuilder builder = new URIBuilder(baseUrl + "/v2/templates");
+            if (templateType != null && !templateType.isEmpty()) {
+                builder.addParameter("type", templateType);
+            }
+            HttpsURLConnection conn = createConnectionAndSetHeaders(builder.toString(), "GET");
+            String response = performGetRequest(conn);
+            return new TemplateList(response);
+        } catch (URISyntaxException e) {
+            LOGGER.log(Level.SEVERE, e.toString(), e);
+            throw new NotificationClientException(e);
+        }
+    }
+
     private String performPostRequest(HttpsURLConnection conn, JSONObject body) throws NotificationClientException {
         try{
             OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -77,4 +77,13 @@ public interface NotificationClientApi {
      */
     Template getTemplateVersion(String templateId, int version) throws NotificationClientException;
 
+    /**
+     * Returns all the templates for your service. Filtered by template type if not null.
+     *
+     * @param templateType If templateType is not empty or null templates will be filtered by type.
+     *          Possible template types are email|sms|letter
+     * @return <code>TemplateList</code>
+     * @throws NotificationClientException
+     */
+    TemplateList getAllTemplates(String templateType) throws NotificationClientException;
 }

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -7,7 +7,7 @@ public interface NotificationClientApi {
     /**
      * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
-     * @param templateId      The template id is visible from the template page in the application.
+     * @param templateId      The template id is visible on the template page in the application.
      * @param emailAddress    The email address
      * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
      *                        Can be an empty map or null when the template does not require placeholders.
@@ -61,11 +61,20 @@ public interface NotificationClientApi {
     /**
      * The getTemplateById returns a <code>Template</code> given the template id.
      *
-     *
-     * @param templateId The template id is visible from the template page in the application.
+     * @param templateId The template id is visible on the template page in the application.
      * @return <code>Template</code>
      * @throws NotificationClientException
      */
     Template getTemplateById(String templateId) throws NotificationClientException;
+
+    /**
+     * The getTemplateVersion returns a <code>Template</code> given the template id and version.
+     *
+     * @param templateId The template id is visible on the template page in the application.
+     * @param version The version of the template to return
+     * @return <code>Template</code>
+     * @throws NotificationClientException
+     */
+    Template getTemplateVersion(String templateId, int version) throws NotificationClientException;
 
 }

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -86,4 +86,15 @@ public interface NotificationClientApi {
      * @throws NotificationClientException
      */
     TemplateList getAllTemplates(String templateType) throws NotificationClientException;
+
+    /**
+     * The getTemplatePreview returns a template with the placeholders replaced with the given personalisation.
+     *
+     * @param templateId The template id is visible from the template page in the application.
+     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
+     *                        Can be an empty map or null when the template does not require placeholders.
+     * @return <code>Template</code>
+     * @throws NotificationClientException
+     */
+    TemplatePreview getTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException;
 }

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -7,7 +7,7 @@ public interface NotificationClientApi {
     /**
      * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
-     * @param templateId      Find templateId by clicking API info for the template you want to send
+     * @param templateId      The template id is visible from the template page in the application.
      * @param emailAddress    The email address
      * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
      *                        Can be an empty map or null when the template does not require placeholders.
@@ -22,7 +22,7 @@ public interface NotificationClientApi {
     /**
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
-     * @param templateId      Find templateId by clicking API info for the template you want to send
+     * @param templateId      The template id is visible from the template page in the application.
      * @param phoneNumber              The mobile phone number
      * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
      *                        Can be an empty map or null when the template does not require placeholders.
@@ -58,5 +58,14 @@ public interface NotificationClientApi {
      */
     NotificationList getNotifications(String status, String notification_type, String reference, String olderThanId) throws NotificationClientException;
 
+    /**
+     * The getTemplateById returns a <code>Template</code> given the template id.
+     *
+     *
+     * @param templateId The template id is visible from the template page in the application.
+     * @return <code>Template</code>
+     * @throws NotificationClientException
+     */
+    Template getTemplateById(String templateId) throws NotificationClientException;
 
 }

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -88,7 +88,7 @@ public interface NotificationClientApi {
     TemplateList getAllTemplates(String templateType) throws NotificationClientException;
 
     /**
-     * The getTemplatePreview returns a template with the placeholders replaced with the given personalisation.
+     * The generateTemplatePreview returns a template with the placeholders replaced with the given personalisation.
      *
      * @param templateId The template id is visible from the template page in the application.
      * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
@@ -96,5 +96,5 @@ public interface NotificationClientApi {
      * @return <code>Template</code>
      * @throws NotificationClientException
      */
-    TemplatePreview getTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException;
+    TemplatePreview generateTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException;
 }

--- a/src/main/java/uk/gov/service/notify/Template.java
+++ b/src/main/java/uk/gov/service/notify/Template.java
@@ -1,0 +1,118 @@
+package uk.gov.service.notify;
+
+import org.joda.time.DateTime;
+import org.json.JSONObject;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class Template {
+    private UUID id;
+    private String templateType;
+    private DateTime createdAt;
+    private DateTime updatedAt;
+    private String createdBy;
+    private int version;
+    private String body;
+    private String subject;
+
+
+    public Template(String content){
+        JSONObject responseBodyAsJson = new JSONObject(content);
+        build(responseBodyAsJson);
+
+    }
+
+    public Template(org.json.JSONObject data){
+        build(data);
+
+    }
+
+    private void build(JSONObject data) {
+        id = UUID.fromString(data.getString("id"));
+        templateType = data.getString("type");
+        createdAt = new DateTime(data.getString("created_at"));
+        updatedAt = data.isNull("updated_at") ? null : new DateTime(data.getString("updated_at"));
+        version = data.getInt("version");
+        body = data.getString("body");
+        subject = data.isNull("subject") ? null : data.getString("subject");
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTemplateType() {
+        return templateType;
+    }
+
+    public void setTemplateType(String templateType) {
+        this.templateType = templateType;
+    }
+
+    public DateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(DateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Optional<DateTime> getUpdatedAt() {
+        return Optional.ofNullable(updatedAt);
+    }
+
+    public void setUpdatedAt(DateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public Optional<String> getSubject() {
+        return Optional.ofNullable(subject);
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    @Override
+    public String toString() {
+        return "Template{" +
+                "id=" + id +
+                ", templateType='" + templateType + '\'' +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", createdBy='" + createdBy + '\'' +
+                ", version=" + version +
+                ", body='" + body + '\'' +
+                ", subject='" + subject + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/service/notify/TemplateList.java
+++ b/src/main/java/uk/gov/service/notify/TemplateList.java
@@ -1,0 +1,34 @@
+package uk.gov.service.notify;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TemplateList {
+    private List<Template> templates;
+
+    public TemplateList(String content){
+        JSONObject data = new JSONObject(content);
+
+        templates =  new ArrayList<>();
+
+        JSONArray templatesData = data.getJSONArray("templates");
+        for(int i = 0; i < templatesData.length(); i++){
+            JSONObject template = templatesData.getJSONObject(i);
+            templates.add(new Template(template));
+        }
+    }
+
+    public List<Template> getTemplates() {
+        return templates;
+    }
+
+    @Override
+    public String toString() {
+        return "TemplateList{" +
+                "templates=" + templates +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/service/notify/TemplatePreview.java
+++ b/src/main/java/uk/gov/service/notify/TemplatePreview.java
@@ -1,0 +1,85 @@
+package uk.gov.service.notify;
+
+import org.json.JSONObject;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class TemplatePreview {
+        private UUID id;
+        private String templateType;
+        private int version;
+        private String body;
+        private String subject;
+
+
+        public TemplatePreview(String content){
+            JSONObject responseBodyAsJson = new JSONObject(content);
+            build(responseBodyAsJson);
+
+        }
+
+        public TemplatePreview(org.json.JSONObject data){
+            build(data);
+
+        }
+
+        private void build(JSONObject data) {
+            id = UUID.fromString(data.getString("id"));
+            templateType = data.getString("type");
+            version = data.getInt("version");
+            body = data.getString("body");
+            subject = data.isNull("subject") ? null : data.getString("subject");
+        }
+
+        public UUID getId() {
+            return id;
+        }
+
+        public void setId(UUID id) {
+            this.id = id;
+        }
+
+        public String getTemplateType() {
+            return templateType;
+        }
+
+        public void setTemplateType(String templateType) {
+            this.templateType = templateType;
+        }
+
+        public int getVersion() {
+            return version;
+        }
+
+        public void setVersion(int version) {
+            this.version = version;
+        }
+
+        public String getBody() {
+            return body;
+        }
+
+        public void setBody(String body) {
+            this.body = body;
+        }
+
+        public Optional<String> getSubject() {
+            return Optional.ofNullable(subject);
+        }
+
+        public void setSubject(String subject) {
+            this.subject = subject;
+        }
+
+        @Override
+        public String toString() {
+            return "Template{" +
+                    "id=" + id +
+                    ", templateType='" + templateType + '\'' +
+                    ", version=" + version +
+                    ", body='" + body + '\'' +
+                    ", subject='" + subject + '\'' +
+                    '}';
+        }
+    }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-project.version=3.1.3-RELEASE
+project.version=3.2.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -102,6 +102,17 @@ public class ClientIntegrationTestIT {
         assertNotNull(template.getSubject());
     }
 
+    @Test
+    public void testGetTemplateVersion() throws NotificationClientException {
+        NotificationClient client = getClient();
+        Template template = client.getTemplateVersion(System.getenv("SMS_TEMPLATE_ID"), 1);
+        assertEquals(System.getenv("SMS_TEMPLATE_ID"), template.getId().toString());
+        assertNotNull(template.getVersion());
+        assertNotNull(template.getCreatedAt());
+        assertNotNull(template.getTemplateType());
+        assertNotNull(template.getBody());
+    }
+
     private NotificationClient getClient(){
         String apiKey = System.getenv("API_KEY");
         String baseUrl = System.getenv("NOTIFY_API_URL");

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -113,6 +113,13 @@ public class ClientIntegrationTestIT {
         assertNotNull(template.getBody());
     }
 
+    @Test
+    public void testGetAllTemplates() throws NotificationClientException {
+        NotificationClient client = getClient();
+        TemplateList templateList = client.getAllTemplates("");
+        assertTrue(2 <= templateList.getTemplates().size());
+    }
+
     private NotificationClient getClient(){
         String apiKey = System.getenv("API_KEY");
         String baseUrl = System.getenv("NOTIFY_API_URL");

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -126,12 +126,13 @@ public class ClientIntegrationTestIT {
         HashMap<String, String> personalisation = new HashMap<>();
         String uniqueName = UUID.randomUUID().toString();
         personalisation.put("name", uniqueName);
-        TemplatePreview template = client.getTemplatePreview(System.getenv("EMAIL_TEMPLATE_ID"), personalisation);
+        TemplatePreview template = client.generateTemplatePreview(System.getenv("EMAIL_TEMPLATE_ID"), personalisation);
         assertEquals(System.getenv("EMAIL_TEMPLATE_ID"), template.getId().toString());
         assertNotNull(template.getVersion());
         assertNotNull(template.getTemplateType());
         assertNotNull(template.getBody());
         assertNotNull(template.getSubject());
+        assertTrue(template.getBody().contains(uniqueName));
     }
 
     @Test
@@ -141,7 +142,7 @@ public class ClientIntegrationTestIT {
         String uniqueName = UUID.randomUUID().toString();
         personalisation.put("name", uniqueName);
         try {
-            TemplatePreview template = client.getTemplatePreview(System.getenv("SMS_TEMPLATE_ID"), personalisation);
+            TemplatePreview template = client.generateTemplatePreview(System.getenv("SMS_TEMPLATE_ID"), personalisation);
         } catch (NotificationClientException e) {
             assert(e.getMessage().contains("Template missing personalisation: name"));
             assert e.getHttpResult() == 400;

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -120,6 +120,35 @@ public class ClientIntegrationTestIT {
         assertTrue(2 <= templateList.getTemplates().size());
     }
 
+    @Test
+    public void testGetTemplatePreview() throws NotificationClientException {
+        NotificationClient client = getClient();
+        HashMap<String, String> personalisation = new HashMap<>();
+        String uniqueName = UUID.randomUUID().toString();
+        personalisation.put("name", uniqueName);
+        TemplatePreview template = client.getTemplatePreview(System.getenv("EMAIL_TEMPLATE_ID"), personalisation);
+        assertEquals(System.getenv("EMAIL_TEMPLATE_ID"), template.getId().toString());
+        assertNotNull(template.getVersion());
+        assertNotNull(template.getTemplateType());
+        assertNotNull(template.getBody());
+        assertNotNull(template.getSubject());
+    }
+
+    @Test
+    public void testGetTemplatePreviewThrowsErrorIfMissingPersonalisation() throws NotificationClientException {
+        NotificationClient client = getClient();
+        HashMap<String, String> personalisation = new HashMap<>();
+        String uniqueName = UUID.randomUUID().toString();
+        personalisation.put("name", uniqueName);
+        try {
+            TemplatePreview template = client.getTemplatePreview(System.getenv("SMS_TEMPLATE_ID"), personalisation);
+        } catch (NotificationClientException e) {
+            assert(e.getMessage().contains("Template missing personalisation: name"));
+            assert e.getHttpResult() == 400;
+            assert(e.getMessage().contains(" \"error\": \"BadRequestError\""));
+        }
+    }
+
     private NotificationClient getClient(){
         String apiKey = System.getenv("API_KEY");
         String baseUrl = System.getenv("NOTIFY_API_URL");

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -90,6 +90,18 @@ public class ClientIntegrationTestIT {
         assertEquals(response.getNotificationId(), notifications.getNotifications().get(0).getId());
     }
 
+    @Test
+    public void testGetTemplateById() throws NotificationClientException {
+        NotificationClient client = getClient();
+        Template template = client.getTemplateById(System.getenv("EMAIL_TEMPLATE_ID"));
+        assertEquals(System.getenv("EMAIL_TEMPLATE_ID"), template.getId().toString());
+        assertNotNull(template.getVersion());
+        assertNotNull(template.getCreatedAt());
+        assertNotNull(template.getTemplateType());
+        assertNotNull(template.getBody());
+        assertNotNull(template.getSubject());
+    }
+
     private NotificationClient getClient(){
         String apiKey = System.getenv("API_KEY");
         String baseUrl = System.getenv("NOTIFY_API_URL");

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -43,7 +43,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.1.3-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.2.0-RELEASE");
     }
 
     @Test

--- a/src/test/java/uk/gov/service/notify/TemplatePreviewTest.java
+++ b/src/test/java/uk/gov/service/notify/TemplatePreviewTest.java
@@ -1,0 +1,30 @@
+package uk.gov.service.notify;
+
+import org.jose4j.json.internal.json_simple.JSONObject;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+public class TemplatePreviewTest {
+
+    @Test
+    public void testTemplatePreview_canCreateObjectFromJson() {
+        JSONObject content = new JSONObject();
+        String id = UUID.randomUUID().toString();
+        content.put("id", id);
+        content.put("type", "email");
+        content.put("version", 3);
+        content.put("body", "The body of the template. For ((name)) eyes only.");
+        content.put("subject", "Private email");
+
+        TemplatePreview template = new TemplatePreview(content.toString());
+        assertEquals(UUID.fromString(id), template.getId());
+        assertEquals("email", template.getTemplateType());
+        assertEquals(3, template.getVersion());
+        assertEquals("The body of the template. For ((name)) eyes only.", template.getBody());
+        assertEquals(Optional.of("Private email"), template.getSubject());
+    }
+}

--- a/src/test/java/uk/gov/service/notify/TemplateTest.java
+++ b/src/test/java/uk/gov/service/notify/TemplateTest.java
@@ -1,0 +1,61 @@
+package uk.gov.service.notify;
+
+
+import org.joda.time.DateTime;
+import org.jose4j.json.internal.json_simple.JSONObject;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+public class TemplateTest {
+
+    @Test
+    public void testTemplate_canCreateObjectFromJson() {
+        JSONObject content = new JSONObject();
+        String id = UUID.randomUUID().toString();
+        content.put("id", id);
+        content.put("type", "email");
+        content.put("created_at", "2017-05-01T08:30:00.000Z");
+        content.put("updated_at", "2017-05-01T08:34:00.000Z");
+        content.put("version", 3);
+        content.put("body", "The body of the template. For ((name)) eyes only.");
+        content.put("subject", "Private email");
+
+        Template template = new Template(content.toString());
+        assertEquals(UUID.fromString(id), template.getId());
+        assertEquals("email", template.getTemplateType());
+        assertEquals(new DateTime("2017-05-01T08:30:00.000Z"), template.getCreatedAt());
+        assertEquals(Optional.of(new DateTime("2017-05-01T08:34:00.000Z")), template.getUpdatedAt());
+        assertEquals(3, template.getVersion());
+        assertEquals("The body of the template. For ((name)) eyes only.", template.getBody());
+        assertEquals(Optional.of("Private email"), template.getSubject());
+    }
+
+
+
+    @Test
+    public void testTemplate_canCreateObjectFromJsonWithOptionals() {
+        JSONObject content = new JSONObject();
+        String id = UUID.randomUUID().toString();
+        content.put("id", id);
+        content.put("type", "email");
+        content.put("created_at", "2017-05-01T08:30:00.000Z");
+        content.put("updated_at", null);
+        content.put("version", 3);
+        content.put("body", "The body of the template. For ((name)) eyes only.");
+        content.put("subject", null);
+
+        Template template = new Template(content.toString());
+        assertEquals(UUID.fromString(id), template.getId());
+        assertEquals("email", template.getTemplateType());
+        assertEquals(new DateTime("2017-05-01T08:30:00.000Z"), template.getCreatedAt());
+        assertEquals(Optional.ofNullable(null), template.getUpdatedAt());
+        assertEquals(3, template.getVersion());
+        assertEquals("The body of the template. For ((name)) eyes only.", template.getBody());
+        assertEquals(Optional.ofNullable(null), template.getSubject());
+    }
+
+}


### PR DESCRIPTION
- Added getTemplateById method in the client.
- Added a method to getTemplateVersion. This will return a template given the id and version.
- Added getAllTemplates method to return all the templates for the service.
- Added a method to preview templates. Given the template id and personalisation the latest template is returned with the placeholders populated with the personalisation.
- Update the documentation. 
- Add CHANGELOG documentations
- Update the version