### PR TITLE
add letter functionality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,8 @@ Then run Java via the Maven exec command with the following arguments:
 ```
 
 You'll be prompted to select an option to submit the API call.
+
+
+## Readme updates
+Don't update README.md - when you run `./update_version.sh` you'll lose any changes you made there - instead make
+changes in README-tpl.md before you call `./update_version.sh`

--- a/README-tpl.md
+++ b/README-tpl.md
@@ -277,6 +277,129 @@ Status code: 400 {
 </table>
 </details>
 
+### Letter:
+
+```java
+HashMap<String, String> personalisation = new HashMap<>();
+personalisation.put("address_line_1", "Her Majesty The Queen"); // required
+personalisation.put("address_line_2", "Buckingham Palace"); // required
+personalisation.put("address_line_3", "London");
+personalisation.put("postcode", "SW1 1AA"); // required
+// add any other personalisation found in your template
+SendLetterResponse response = client.sendLetter(templateId, personalisation, "yourReferenceString");
+```
+
+
+<details>
+<summary>
+SendLetterResponse
+</summary>
+
+If the request is successful, the SendLetterResponse is returned from the client. Attributes of the SendLetterResponse are listed below.
+
+```java
+	UUID notificationId;
+	Optional<String> reference;
+	UUID templateId;
+	int templateVersion;
+	String templateUri;
+	String body;
+	String subject;
+```
+
+Otherwise the client will raise a `NotificationClientException`:
+
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 429 {
+"errors":
+[{
+    "error": "RateLimitError",
+    "message": "Exceeded rate limit for key type TEAM of 10 requests per 10 seconds"
+}]
+}
+</pre>
+</td>
+</tr>
+
+<tr>
+<td>
+<pre>
+Status code: 429 {
+"errors":
+[{
+    "error": "TooManyRequestsError",
+    "message": "Exceeded send limits (50) for today"
+}]
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>
+Status code 400: {
+"errors":
+[{
+    "error": "BadRequestError",
+    "message": "Can"t send to this recipient using a team-only API key"
+]}
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "BadRequestError",
+    "message": "Can"t send to this recipient when service is in trial mode
+                - see https://www.notifications.service.gov.uk/trial-mode"
+}]
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "personalisation address_line_1 is a required property"
+}]
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "BadRequestError",
+    "message": "Cannot send letters with a team api key"
+}]
+}
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
 ### Arguments
 #### `phoneNumber`
 The mobile number the SMS notification is sent to.
@@ -290,6 +413,11 @@ The template id is visible on the template page in the application.
 
 #### `personalisation`
 If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
+
+#### `personalisation` (for letters)
+
+If you are sending a letter, you will need to provide the address fields in the format `"address_line_#"`, numbered from 1 to 6, and also the `"postcode"` field
+The fields `"address_line_1"`, `"address_line_2"` and `"postcode"` are required.
 
 #### `reference`
 An optional unique identifier for the notification or an identifier for a batch of notifications. `reference` can be an empty string or null.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>3.2.0-RELEASE</version>
+        <version>3.3.0-RELEASE</version>
     </dependency>
 
 ```
@@ -58,7 +58,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:3.2.0-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:3.3.0-RELEASE')
 }
 ```
 
@@ -277,6 +277,129 @@ Status code: 400 {
 </table>
 </details>
 
+### Letter:
+
+```java
+HashMap<String, String> personalisation = new HashMap<>();
+personalisation.put("address_line_1", "Her Majesty The Queen"); // required
+personalisation.put("address_line_2", "Buckingham Palace"); // required
+personalisation.put("address_line_3", "London");
+personalisation.put("postcode", "SW1 1AA"); // required
+// add any other personalisation found in your template
+SendLetterResponse response = client.sendLetter(templateId, personalisation, "yourReferenceString");
+```
+
+
+<details>
+<summary>
+SendLetterResponse
+</summary>
+
+If the request is successful, the SendLetterResponse is returned from the client. Attributes of the SendLetterResponse are listed below.
+
+```java
+	UUID notificationId;
+	Optional<String> reference;
+	UUID templateId;
+	int templateVersion;
+	String templateUri;
+	String body;
+	String subject;
+```
+
+Otherwise the client will raise a `NotificationClientException`:
+
+<table>
+<thead>
+<tr>
+<th>message</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>
+Status code: 429 {
+"errors":
+[{
+    "error": "RateLimitError",
+    "message": "Exceeded rate limit for key type TEAM of 10 requests per 10 seconds"
+}]
+}
+</pre>
+</td>
+</tr>
+
+<tr>
+<td>
+<pre>
+Status code: 429 {
+"errors":
+[{
+    "error": "TooManyRequestsError",
+    "message": "Exceeded send limits (50) for today"
+}]
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>
+Status code 400: {
+"errors":
+[{
+    "error": "BadRequestError",
+    "message": "Can"t send to this recipient using a team-only API key"
+]}
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "BadRequestError",
+    "message": "Can"t send to this recipient when service is in trial mode
+                - see https://www.notifications.service.gov.uk/trial-mode"
+}]
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "ValidationError",
+    "message": "personalisation address_line_1 is a required property"
+}]
+}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>
+Status code: 400 {
+"errors":
+[{
+    "error": "BadRequestError",
+    "message": "Cannot send letters with a team api key"
+}]
+}
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
 ### Arguments
 #### `phoneNumber`
 The mobile number the SMS notification is sent to.
@@ -290,6 +413,11 @@ The template id is visible on the template page in the application.
 
 #### `personalisation`
 If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
+
+#### `personalisation` (for letters)
+
+If you are sending a letter, you will need to provide the address fields in the format `"address_line_#"`, numbered from 1 to 6, and also the `"postcode"` field
+The fields `"address_line_1"`, `"address_line_2"` and `"postcode"` are required.
 
 #### `reference`
 An optional unique identifier for the notification or an identifier for a batch of notifications. `reference` can be an empty string or null.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.2.0-RELEASE</version>
+    <version>3.3.0-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/script/generate_docker_env.sh
+++ b/script/generate_docker_env.sh
@@ -17,6 +17,7 @@ env_vars=(
     FUNCTIONAL_TEST_NUMBER
     EMAIL_TEMPLATE_ID
     SMS_TEMPLATE_ID
+    LETTER_TEMPLATE_ID
 )
 
 for env_var in "${env_vars[@]}"; do

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -162,6 +162,26 @@ public class NotificationClient implements NotificationClientApi {
         return new SendSmsResponse(response);
     }
 
+
+    /**
+     * The sendLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param templateId      Find templateId by clicking API info for the template you want to send
+     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob.
+     *                        Must include the keys "address_line_1", "address_line_2" and "postcode".
+     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
+     *                        This reference can be unique or used used to refer to a batch of notifications.
+     *                        Can be an empty string or null, when you do not require a reference for the notifications.
+     * @return <code>SendLetterResponse</code>
+     * @throws NotificationClientException
+     */
+    public SendLetterResponse sendLetter(String templateId, Map<String, String> personalisation, String reference) throws NotificationClientException {
+        JSONObject body = createBodyForPostRequest(templateId, null, null, personalisation, reference);
+        HttpsURLConnection conn = createConnectionAndSetHeaders(baseUrl + "/v2/notifications/letter", "POST");
+        String response = performPostRequest(conn, body, HttpsURLConnection.HTTP_CREATED);
+        return new SendLetterResponse(response);
+    }
+
     /**
      * The getNotificationById method will return a <code>Notification</code> for a given notification id.
      * The id is can be retrieved from the <code>NotificationResponse</code> of a <code>sendEmail</code> or <code>sendSms</code> request.

--- a/src/main/java/uk/gov/service/notify/SendLetterResponse.java
+++ b/src/main/java/uk/gov/service/notify/SendLetterResponse.java
@@ -1,0 +1,71 @@
+package uk.gov.service.notify;
+
+import org.json.JSONObject;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class SendLetterResponse {
+    private UUID notificationId;
+    private String reference;
+    private UUID templateId;
+    private int templateVersion;
+    private String templateUri;
+    private String body;
+    private String subject;
+
+
+    public SendLetterResponse(String response) {
+        JSONObject data = new JSONObject(response);
+        notificationId = UUID.fromString(data.getString("id"));
+        reference = data.isNull("reference") ? null : data.getString("reference");
+        JSONObject content = data.getJSONObject("content");
+        body = content.getString("body");
+        subject = content.getString("subject");
+        JSONObject template = data.getJSONObject("template");
+        templateId = UUID.fromString(template.getString("id"));
+        templateVersion = template.getInt("version");
+        templateUri = template.getString("uri");
+    }
+
+    public UUID getNotificationId() {
+        return notificationId;
+    }
+
+    public Optional<String> getReference() {
+        return Optional.ofNullable(reference);
+    }
+
+    public UUID getTemplateId() {
+        return templateId;
+    }
+
+    public int getTemplateVersion() {
+        return templateVersion;
+    }
+
+    public String getTemplateUri() {
+        return templateUri;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    @Override
+    public String toString() {
+        return "SendEmailResponse{" +
+                "notificationId=" + notificationId +
+                ", reference=" + reference +
+                ", templateId=" + templateId +
+                ", templateVersion=" + templateVersion +
+                ", templateUri='" + templateUri + '\'' +
+                ", body='" + body + '\'' +
+                ", subject='" + subject +
+                '}';
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-project.version=3.2.0-RELEASE
+project.version=3.3.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -144,22 +144,6 @@ public class ClientIntegrationTestIT {
         assertTrue(template.getBody().contains(uniqueName));
     }
 
-    @Test
-    public void testGetTemplatePreviewThrowsErrorIfMissingPersonalisation() throws NotificationClientException {
-        NotificationClient client = getClient();
-        HashMap<String, String> personalisation = new HashMap<>();
-        String uniqueName = UUID.randomUUID().toString();
-        personalisation.put("name", uniqueName);
-        try {
-            TemplatePreview template = client.generateTemplatePreview(System.getenv("SMS_TEMPLATE_ID"), personalisation);
-            fail("Expected NotificationClientException: Template missing personalisation: name");
-        } catch (NotificationClientException e) {
-            assert(e.getMessage().contains("Template missing personalisation: name"));
-            assert e.getHttpResult() == 400;
-            assert(e.getMessage().contains(" \"error\": \"BadRequestError\""));
-        }
-    }
-
     private NotificationClient getClient(){
         String apiKey = System.getenv("API_KEY");
         String baseUrl = System.getenv("NOTIFY_API_URL");

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -43,7 +43,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.2.0-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.3.0-RELEASE");
     }
 
     @Test

--- a/src/test/java/uk/gov/service/notify/NotificationListTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationListTest.java
@@ -64,9 +64,34 @@ public class NotificationListTest {
         sms.put("sent_at", "2016-03-01T08:30:03.000Z");
         sms.put("completed_at", "2016-03-01T08:30:43.000Z");
 
+        JSONObject letter = new JSONObject();
+        letter.put("id", id);
+        letter.put("reference", "client_reference");
+        letter.put("email_address", null);
+        letter.put("phone_number", null);
+        letter.put("line_1", "the queen");
+        letter.put("line_2", "buckingham palace");
+        letter.put("line_3", null);
+        letter.put("line_4", null);
+        letter.put("line_5", null);
+        letter.put("line_6", null);
+        letter.put("postcode", "sw1 1aa");
+        letter.put("type", "email");
+        letter.put("status", "delivered");
+        template.put("id", templateId);
+        template.put("version", 1);
+        template.put("uri", "https://api.notifications.service.gov.uk/templates/" + templateId);
+        letter.put("template", template);
+        letter.put("body", "Body of the message");
+        letter.put("subject", null);
+        letter.put("created_at", "2016-03-01T08:30:00.000Z");
+        letter.put("sent_at", "2016-03-01T08:30:03.000Z");
+        letter.put("completed_at", "2016-03-01T08:30:43.000Z");
+
         JSONArray listNotifications = new JSONArray();
         listNotifications.add(email);
         listNotifications.add(sms);
+        listNotifications.add(letter);
         JSONObject content = new JSONObject();
         content.put("notifications", listNotifications);
         JSONObject links = new JSONObject();
@@ -76,7 +101,7 @@ public class NotificationListTest {
 
 
         NotificationList result = new NotificationList(content.toString());
-        assertEquals(2, result.getNotifications().size());
+        assertEquals(3, result.getNotifications().size());
         assertEquals("https://api.notifications.service.gov.uk/notifications", result.getCurrentPageLink());
         assertEquals(Optional.<String>empty(), result.getNextPageLink());
 

--- a/src/test/java/uk/gov/service/notify/NotificationTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationTest.java
@@ -80,7 +80,7 @@ public class NotificationTest {
         content.put("line_5", null);
         content.put("line_6", null);
         content.put("postcode", null);
-        content.put("type", "email");
+        content.put("type", "sms");
         content.put("status", "delivered");
         JSONObject template = new JSONObject();
         String templateId = UUID.randomUUID().toString();
@@ -99,7 +99,7 @@ public class NotificationTest {
         assertEquals(UUID.fromString(id), notification.getId());
         assertEquals(Optional.of("client_reference"), notification.getReference());
         assertEquals(UUID.fromString(templateId), notification.getTemplateId());
-        assertEquals("email", notification.getNotificationType());
+        assertEquals("sms", notification.getNotificationType());
 
         assertEquals(Optional.of("+447111111111"), notification.getPhoneNumber());
         assertEquals(Optional.<String>empty(), notification.getEmailAddress());
@@ -110,6 +110,63 @@ public class NotificationTest {
         assertEquals(Optional.<String>empty(), notification.getLine5());
         assertEquals(Optional.<String>empty(), notification.getLine6());
         assertEquals(Optional.<String>empty(), notification.getPostcode());
+        assertEquals(UUID.fromString(templateId), notification.getTemplateId());
+        assertEquals(1, notification.getTemplateVersion());
+        assertEquals("https://api.notifications.service.gov.uk/templates/" + templateId, notification.getTemplateUri());
+        assertEquals("Body of the message", notification.getBody());
+        assertEquals(Optional.empty(), notification.getSubject());
+        assertEquals(new DateTime("2016-03-01T08:30:00.000Z"), notification.getCreatedAt());
+        assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
+        assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
+
+    }
+
+
+    @Test
+    public void testLetterNotification_canCreateObjectFromJson() {
+        JSONObject content = new JSONObject();
+        String id = UUID.randomUUID().toString();
+        content.put("id", id);
+        content.put("reference", "client_reference");
+        content.put("email_address", null);
+        content.put("phone_number", null);
+        content.put("line_1", "the queen");
+        content.put("line_2", "buckingham palace");
+        content.put("line_3", null);
+        content.put("line_4", null);
+        content.put("line_5", null);
+        content.put("line_6", null);
+        content.put("postcode", "sw1 1aa");
+        content.put("type", "letter");
+        content.put("status", "delivered");
+        JSONObject template = new JSONObject();
+        String templateId = UUID.randomUUID().toString();
+        template.put("id", templateId);
+        template.put("version", 1);
+        template.put("uri", "https://api.notifications.service.gov.uk/templates/" + templateId);
+        content.put("template", template);
+        content.put("body", "Body of the message");
+        content.put("subject", null);
+        content.put("created_at", "2016-03-01T08:30:00.000Z");
+        content.put("sent_at", "2016-03-01T08:30:03.000Z");
+        content.put("completed_at", "2016-03-01T08:30:43.000Z");
+
+
+        Notification notification = new Notification(content.toString());
+        assertEquals(UUID.fromString(id), notification.getId());
+        assertEquals(Optional.of("client_reference"), notification.getReference());
+        assertEquals(UUID.fromString(templateId), notification.getTemplateId());
+        assertEquals("letter", notification.getNotificationType());
+
+        assertEquals(Optional.<String>empty(), notification.getPhoneNumber());
+        assertEquals(Optional.<String>empty(), notification.getEmailAddress());
+        assertEquals(Optional.of("the queen"), notification.getLine1());
+        assertEquals(Optional.of("buckingham palace"), notification.getLine2());
+        assertEquals(Optional.<String>empty(), notification.getLine3());
+        assertEquals(Optional.<String>empty(), notification.getLine4());
+        assertEquals(Optional.<String>empty(), notification.getLine5());
+        assertEquals(Optional.<String>empty(), notification.getLine6());
+        assertEquals(Optional.of("sw1 1aa"), notification.getPostcode());
         assertEquals(UUID.fromString(templateId), notification.getTemplateId());
         assertEquals(1, notification.getTemplateVersion());
         assertEquals("https://api.notifications.service.gov.uk/templates/" + templateId, notification.getTemplateUri());

--- a/src/test/java/uk/gov/service/notify/SendLetterResponseTest.java
+++ b/src/test/java/uk/gov/service/notify/SendLetterResponseTest.java
@@ -8,33 +8,33 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 
-public class SendSmsResponseTest {
+public class SendLetterResponseTest {
 
     @Test
-    public void testNotificationResponseForSmsResponse(){
-        JSONObject postSmsReponse = new JSONObject();
+    public void testNotificationResponseForLetterResponse(){
+        JSONObject postLetterResponse = new JSONObject();
         UUID id = UUID.randomUUID();
-        postSmsReponse.put("id", id);
-        postSmsReponse.put("reference", "clientReference");
+        postLetterResponse.put("id", id);
+        postLetterResponse.put("reference", "clientReference");
         JSONObject template = new JSONObject();
         UUID templateId = UUID.randomUUID();
         template.put("id", templateId);
         template.put("version", 1);
         template.put("uri", "https://api.notifications.service.gov.uk/templates/"+templateId);
-        postSmsReponse.put("template", template);
+        postLetterResponse.put("template", template);
         JSONObject content = new JSONObject();
         content.put("body", "hello Fred");
-        content.put("from_number", "senderId");
-        postSmsReponse.put("content", content);
+        content.put("subject", "Reminder for thing");
+        postLetterResponse.put("content", content);
 
 
-        SendSmsResponse response = new SendSmsResponse(postSmsReponse.toString());
+        SendLetterResponse response = new SendLetterResponse(postLetterResponse.toString());
         assertEquals(id, response.getNotificationId());
         assertEquals(Optional.of("clientReference"), response.getReference());
         assertEquals(templateId, response.getTemplateId());
         assertEquals("https://api.notifications.service.gov.uk/templates/"+templateId, response.getTemplateUri());
         assertEquals(1, response.getTemplateVersion());
         assertEquals("hello Fred", response.getBody());
-        assertEquals(Optional.of("senderId"), response.getFromNumber());
+        assertEquals("Reminder for thing", response.getSubject());
     }
 }


### PR DESCRIPTION
To send a letter, use notifications_api_client.send_letter_notification.
Unlike sms and email, the personalisation argument is required, as it
contains the address. The address should be included in fields
`address_line_1`, `address_line_2`, up to `address_line_6`, and
`postcode`. `address_line_1` and `postcode` are required.