### PR TITLE
Update Java docs for Letters API

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ Status code: 400 {
 </table>
 </details>
 
+<details>
+<summary>Arguments</summary>
+
+#### `phoneNumber`
+The mobile number the SMS notification is sent to.
+
+#### `templateId`
+The template id is visible on the template page in the application.
+
+#### `personalisation`
+If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
+
+#### `reference`
+An optional unique identifier for the notification or an identifier for a batch of notifications. `reference` can be an empty string or null.
+
+</details>
 
 ### Email:
 
@@ -277,14 +293,32 @@ Status code: 400 {
 </table>
 </details>
 
+<details>
+<summary>Arguments</summary>
+
+#### `emailAddress`
+The email address the email notification is sent to.
+
+#### `templateId`
+
+The template id is visible on the template page in the application.
+
+#### `personalisation`
+If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
+
+#### `reference`
+An optional unique identifier for the notification or an identifier for a batch of notifications. `reference` can be an empty string or null.
+
+</details>
+
 ### Letter:
 
 ```java
 HashMap<String, String> personalisation = new HashMap<>();
-personalisation.put("address_line_1", "Her Majesty The Queen"); // required
-personalisation.put("address_line_2", "Buckingham Palace"); // required
+personalisation.put("address_line_1", "The Occupier"); // required
+personalisation.put("address_line_2", "123 High Street"); // required
 personalisation.put("address_line_3", "London");
-personalisation.put("postcode", "SW1 1AA"); // required
+personalisation.put("postcode", "SW14 6BH"); // required
 // add any other personalisation found in your template
 SendLetterResponse response = client.sendLetter(templateId, personalisation, "yourReferenceString");
 ```
@@ -400,27 +434,22 @@ Status code: 400 {
 </table>
 </details>
 
-### Arguments
-#### `phoneNumber`
-The mobile number the SMS notification is sent to.
-
-#### `emailAddress`
-The email address the email notification is sent to.
+<details>
+<summary>Arguments</summary>
 
 #### `templateId`
-
 The template id is visible on the template page in the application.
 
 #### `personalisation`
-If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
+If you are sending a letter, you will need to provide the address fields in the format `"address_line_#"`, numbered from 1 to 6, and also the `"postcode"` field.
 
-#### `personalisation` (for letters)
-
-If you are sending a letter, you will need to provide the address fields in the format `"address_line_#"`, numbered from 1 to 6, and also the `"postcode"` field
-The fields `"address_line_1"`, `"address_line_2"` and `"postcode"` are required.
+The fields `"address_line_1"`, `"address_line_2"` and `"postcode"` are required. We support up to six address lines.
 
 #### `reference`
 An optional unique identifier for the notification or an identifier for a batch of notifications. `reference` can be an empty string or null.
+
+</details>
+
 
 ## Get the status of one message
 
@@ -547,13 +576,39 @@ Status code: 400 {
 
 #### `status`
 
+##### Text message
+
 You can filter the notifications by the following options:
 
 * `sending` - the message is queued to be sent by the provider.
 * `delivered` - the message was successfully delivered.
 * `failed` - this will return all failure statuses `permanent-failure`, `temporary-failure` and `technical-failure`.
-* `permanent-failure` - the provider was unable to deliver message, email or phone number does not exist; remove this recipient from your list.
-* `temporary-failure` - the provider was unable to deliver message, email box was full or the phone was turned off; you can try to send the message again.
+* `permanent-failure` - the provider was unable to deliver message, phone number does not exist; remove this recipient from your list.
+* `temporary-failure` - the provider was unable to deliver message, the phone was turned off; you can try to send the message again.
+* `technical-failure` - Notify had a technical failure; you can try to send the message again.
+
+You can pass an empty string or null to ignore the filter.
+
+##### Email
+
+You can filter the notifications by the following options:
+
+* `sending` - the message is queued to be sent by the provider.
+* `delivered` - the message was successfully delivered.
+* `failed` - this will return all failure statuses `permanent-failure`, `temporary-failure` and `technical-failure`.
+* `permanent-failure` - the provider was unable to deliver message, email does not exist; remove this recipient from your list.
+* `temporary-failure` - the provider was unable to deliver message, email box was full; you can try to send the message again.
+* `technical-failure` - Notify had a technical failure; you can try to send the message again.
+
+You can pass an empty string or null to ignore the filter.
+
+##### Letter
+
+You can filter the notifications by the following options:
+
+* `created` - the message has been created.
+* `sending` - the message is queued to be sent by the provider.
+* `failed` - this will return all failure statuses `permanent-failure`, `temporary-failure` and `technical-failure`.
 * `technical-failure` - Notify had a technical failure; you can try to send the message again.
 
 You can pass an empty string or null to ignore the filter.


### PR DESCRIPTION
Send Messages section:
- Amended arguments to be channel-specific and copied into each channel section from the end of the Send Messages section

Get Status of all messages:
- Split out statuses by channel and amended failed statuses to be channel appropriate
- Updated statuses for Letters to created, sending, failed, technical failure

Corrections:
- Added note saying that we support up to six address lines
- Changed all fake addresses to 123 High street