### PR TITLE
Java Docs Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GOV.UK Notify Java client
 
+This documentation is for developers interested in using this Java client to integrate their government service with GOV.UK Notify.
+
 ## Installation
 
 ### Maven
@@ -313,13 +315,24 @@ An optional unique identifier for the notification or an identifier for a batch 
 
 ### Letter:
 
+The letter must contain:
+
+- mandatory address fields
+- optional address fields if applicable
+- fields from template
+
 ```java
 HashMap<String, String> personalisation = new HashMap<>();
-personalisation.put("address_line_1", "The Occupier"); // required
-personalisation.put("address_line_2", "123 High Street"); // required
-personalisation.put("address_line_3", "London");
-personalisation.put("postcode", "SW14 6BH"); // required
-// add any other personalisation found in your template
+personalisation.put("address_line_1", "The Occupier"); // mandatory address field
+personalisation.put("address_line_2", "Flat 2"); // mandatory address field
+personalisation.put("address_line_3", "123 High Street"); // optional address field
+personalisation.put("address_line_4", "Richmond upon Thames"); // optional address field
+personalisation.put("address_line_5", "London"); // optional address field
+personalisation.put("address_line_6", "Middlesex"); // optional address field
+personalisation.put("postcode", "SW14 6BH"); // mandatory address field
+personalisation.put("application_id", "1234"); // field from template
+personalisation.put("application_date", "2017-01-01"); // field from template
+
 SendLetterResponse response = client.sendLetter(templateId, personalisation, "yourReferenceString");
 ```
 
@@ -441,7 +454,12 @@ Status code: 400 {
 The template id is visible on the template page in the application.
 
 #### `personalisation`
-If you are sending a letter, you will need to provide the address fields in the format `"address_line_#"`, numbered from 1 to 6, and also the `"postcode"` field.
+
+The letter must contain:
+
+- mandatory address fields
+- optional address fields if applicable
+- fields from template
 
 The fields `"address_line_1"`, `"address_line_2"` and `"postcode"` are required. We support up to six address lines.
 
@@ -572,7 +590,8 @@ Status code: 400 {
 </table>
 </details>
 
-### Arguments
+<details>
+<summary>Arguments</summary>
 
 #### `status`
 
@@ -630,6 +649,7 @@ You can pass an empty string or null to ignore the filter.
 You can get the notifications older than a given `Notification.notificationId`.
 You can pass an empty string or null to ignore the filter
 
+</details>
 
 ## Get a template by ID
 This will return the latest version of the template. Use [getTemplateVersion](#get-a-template-by-id-and-version) to retrieve a specific template version.
@@ -687,10 +707,13 @@ Status code: 400 {
 </table>
 </details>
 
-### Arguments
+<details>
+<summary>Arguments</summary>
 
 #### `templateId`
 The template id is visible on the template page in the application.
+
+</details>
 
 
 ## Get a template by ID and version
@@ -749,14 +772,16 @@ Status code: 400 {
 </table>
 </details>
 
-### Arguments
+<details>
+<summary>Arguments</summary>
 
-#### `templateId`
+### `templateId`
 The template id is visible on the template page in the application.
 
-#### `version`
+### `version`
 A history of the template is kept. There is a link to `See previous versions` on the template page in the application.
 
+</details>
 
 ## Get all templates
 This will return the latest version of each template for your service.
@@ -779,10 +804,11 @@ If no templates exist for a template type or there no templates for a service, t
 
 Otherwise the client will raise a `NotificationClientException`.
 
-
 </details>
 
-### Arguments
+
+<details>
+<summary>Arguments</summary>
 
 #### `templateType`
 You can filter the templates by the following options:
@@ -792,6 +818,7 @@ You can filter the templates by the following options:
 * `letter`
 You can also pass in an empty string or null to ignore the filter.
 
+</details>
 
 ## Generate a preview template
 This will return the contents of a template with the placeholders replaced with the given personalisation.
@@ -845,10 +872,14 @@ Status code: 400 {
 
 </details>
 
-### Arguments
+<details>
+ 
+<summary>Arguments</summary>
 
 #### `templateId`
 The template id is visible on the template page in the application.
 
 #### `personalisation`
 If a template has placeholders, you need to provide their values. `personalisation` can be an empty or null in which case no placeholders are provided for the notification.
+
+</details>


### PR DESCRIPTION
- Added short introduction saying what the client is and who should use it.
- Amended definition for personalisation in the letter section to better describe required and optional address lines and template fields
- Made arguments sections collapsible