### PR TITLE
Add estimated delivery for letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
+## 3.4.0-RELEASE
+* `Notification` now contains `estimatedDelivery`
+  - Shows when the letter is expected to be picked up by Royal Mail from our printing providers.
+  - `null` for sms and email.
+* `NotificationClientApi` interface updated to include `sendLetter`` functionality.
+
+## 3.3.0-RELEASE
+* `sendLetter` added to NotificationClient
+  - SendLetterResponse sendLetter(String templateId, Map<String, String> personalisation, String reference) throws NotificationClientException
+  - `personalisation` map is required, and must contain the recipient's address details.
+  - as with sms and email, `reference` is optional.
+
 ## 3.2.0-RELEASE
-* Template endpoints added to the NotificationsClient
+* Template endpoints added to the NotificationClient
 * `getTemplateById` - get the latest version of a template by id.
 * `getTemplateVersion` - get the template by id and version.
 * `getAllTemplates` - get all templates, can be filtered by template type.
 * `generateTemplatePreview` - get the contents of a template with the placeholders replaced with the given personalisation.
-* See the README for more information about the new template methods. 
+* See the README for more information about the new template methods.
 
 
 ## 3.1.3-RELEASE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ On a command line build the project with Maven:
 Then run Java via the Maven exec command with the following arguments:
 
 ```shell
-> mvn exec:java -Dexec.mainClass=TestNotificationClient -Dexec.args="api-key-id service-id https://api.notifications.service.gov.uk"
+> mvn exec:java -Dexec.mainClass=TestNotificationClient -Dexec.args="api-key-id https://api.notifications.service.gov.uk"
 ```
 
 You'll be prompted to select an option to submit the API call.

--- a/README.md
+++ b/README.md
@@ -473,7 +473,8 @@ If successful a `notification` is returned. Below is a list of attributes in a `
     Optional<String subject;
     DateTime createdAt;
     Optional<DateTime> sentAt;
-    Optional<DateTime> completedAt;
+		Optional<DateTime> completedAt;
+    Optional<DateTime> estimatedDelivery;
 ```
 
 Otherwise the client will raise a `NotificationClientException`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>3.3.1-RELEASE</version>
+        <version>3.4.0-RELEASE</version>
     </dependency>
 
 ```
@@ -60,7 +60,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:3.3.1-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:3.4.0-RELEASE')
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.3.1-RELEASE</version>
+    <version>3.4.0-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/TestNotificationClient.java
+++ b/src/main/java/TestNotificationClient.java
@@ -16,12 +16,8 @@ public class TestNotificationClient {
     /**
      * A command line tool to test the integration of the NotificationClient
      * Run by using this command:
-     * mvn exec:java -Dexec.mainClass=TestNotificationClient -Dexec.args="api_key service_ID https://api.notifications.service.gov.uk"
-     * OR
-     * mvn exec:java -Dexec.mainClass=TestNotificationClient -Dexec.args="single_api_key https://api.notifications.service.gov.uk"
-     *    where single_api_key = api key name + service id + api key
-     * Args: either enter 3 arguments: api key, service id, baseUrl
-     *      or 2: api key, baseUrl (single api key that is the api key name + service id + api key)
+     * mvn exec:java -Dexec.mainClass=TestNotificationClient -Dexec.args="api_key https://api.notifications.service.gov.uk"
+     *    where baseUrl is optional
      *
      * @param args
      * @throws Exception
@@ -35,7 +31,7 @@ public class TestNotificationClient {
             client = new NotificationClient(args[0], args[1]);
         }
         else{
-            System.out.println("expected either 2 arguments  got: " + args.length);
+            System.out.println("expected either 2 arguments got: " + args.length);
             System.exit(1);
         }
         BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));

--- a/src/main/java/uk/gov/service/notify/Notification.java
+++ b/src/main/java/uk/gov/service/notify/Notification.java
@@ -28,6 +28,7 @@ public class Notification {
     private DateTime createdAt;
     private DateTime sentAt;
     private DateTime completedAt;
+    private DateTime estimatedDelivery;
 
     public Notification(String content){
         JSONObject responseBodyAsJson = new JSONObject(content);
@@ -61,6 +62,7 @@ public class Notification {
         createdAt = new DateTime(data.getString("created_at"));
         sentAt =  data.isNull("sent_at") ? null : new DateTime(data.getString("sent_at"));
         completedAt = data.isNull("completed_at") ? null : new DateTime(data.getString("completed_at"));
+        estimatedDelivery = data.isNull("estimated_delivery") ? null : new DateTime(data.getString("estimated_delivery"));
     }
 
     public UUID getId() {
@@ -147,6 +149,13 @@ public class Notification {
         return Optional.ofNullable(completedAt);
     }
 
+    /**
+     * estimatedDelivery is only present on letters
+     */
+    public Optional<DateTime> getEstimatedDelivery() {
+        return Optional.ofNullable(estimatedDelivery);
+    }
+
     @Override
     public String toString() {
         return "Notification{" +
@@ -171,6 +180,7 @@ public class Notification {
                 ", createdAt=" + createdAt +
                 ", sentAt=" + sentAt +
                 ", completedAt=" + completedAt +
+                ", estimatedDelivery=" + estimatedDelivery +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -35,6 +35,20 @@ public interface NotificationClientApi {
     SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference) throws NotificationClientException;
 
     /**
+     * The sendLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param templateId      Find templateId by clicking API info for the template you want to send
+     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob.
+     *                        Must include the keys "address_line_1", "address_line_2" and "postcode".
+     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
+     *                        This reference can be unique or used used to refer to a batch of notifications.
+     *                        Can be an empty string or null, when you do not require a reference for the notifications.
+     * @return <code>SendLetterResponse</code>
+     * @throws NotificationClientException
+     */
+    SendLetterResponse sendLetter(String templateId, Map<String, String> personalisation, String reference) throws NotificationClientException;
+
+    /**
      * The getNotificationById method will return a <code>Notification</code> for a given notification id.
      * The id is can be retrieved from the <code>NotificationResponse</code> of a <code>sendEmail</code> or <code>sendSms</code> request.
      *

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-project.version=3.3.1-RELEASE
+project.version=3.4.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -43,7 +43,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.3.1-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.4.0-RELEASE");
     }
 
     @Test

--- a/src/test/java/uk/gov/service/notify/NotificationTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationTest.java
@@ -62,7 +62,7 @@ public class NotificationTest {
         assertEquals(new DateTime("2016-03-01T08:30:00.000Z"), notification.getCreatedAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
-        assertEquals(Optional.of(new Datetime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
+        assertEquals(Optional.of(new DateTime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
 
     }
 
@@ -119,7 +119,7 @@ public class NotificationTest {
         assertEquals(new DateTime("2016-03-01T08:30:00.000Z"), notification.getCreatedAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
-        assertEquals(Optional.of(new Datetime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
+        assertEquals(Optional.of(new DateTime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
 
     }
 
@@ -177,6 +177,6 @@ public class NotificationTest {
         assertEquals(new DateTime("2016-03-01T08:30:00.000Z"), notification.getCreatedAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
-        assertEquals(Optional.of(new Datetime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
+        assertEquals(Optional.of(new DateTime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
     }
 }

--- a/src/test/java/uk/gov/service/notify/NotificationTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationTest.java
@@ -39,7 +39,7 @@ public class NotificationTest {
         content.put("created_at", "2016-03-01T08:30:00.000Z");
         content.put("sent_at", "2016-03-01T08:30:03.000Z");
         content.put("completed_at", "2016-03-01T08:30:43.000Z");
-
+        content.put("estimated_delivery", "2016-03-03T16:00:00.000Z");
         Notification notification = new Notification(content.toString());
         assertEquals(UUID.fromString(id), notification.getId());
         assertEquals(Optional.of("client_reference"), notification.getReference());
@@ -62,6 +62,7 @@ public class NotificationTest {
         assertEquals(new DateTime("2016-03-01T08:30:00.000Z"), notification.getCreatedAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
+        assertEquals(Optional.of(new Datetime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
 
     }
 
@@ -93,7 +94,7 @@ public class NotificationTest {
         content.put("created_at", "2016-03-01T08:30:00.000Z");
         content.put("sent_at", "2016-03-01T08:30:03.000Z");
         content.put("completed_at", "2016-03-01T08:30:43.000Z");
-
+        content.put("estimated_delivery", "2016-03-03T16:00:00.000Z");
 
         Notification notification = new Notification(content.toString());
         assertEquals(UUID.fromString(id), notification.getId());
@@ -118,6 +119,7 @@ public class NotificationTest {
         assertEquals(new DateTime("2016-03-01T08:30:00.000Z"), notification.getCreatedAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
+        assertEquals(Optional.of(new Datetime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
 
     }
 
@@ -150,7 +152,7 @@ public class NotificationTest {
         content.put("created_at", "2016-03-01T08:30:00.000Z");
         content.put("sent_at", "2016-03-01T08:30:03.000Z");
         content.put("completed_at", "2016-03-01T08:30:43.000Z");
-
+        content.put("estimated_delivery", "2016-03-03T16:00:00.000Z");
 
         Notification notification = new Notification(content.toString());
         assertEquals(UUID.fromString(id), notification.getId());
@@ -175,6 +177,6 @@ public class NotificationTest {
         assertEquals(new DateTime("2016-03-01T08:30:00.000Z"), notification.getCreatedAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
-
+        assertEquals(Optional.of(new Datetime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
     }
 }


### PR DESCRIPTION
when querying letter notifications, we now return an `estimatedDelivery` Datetime object.

Also, updated the `NotificationClientApi` interface so you can stub out `sendLetter`, and updated the changelog for 3.3.0 - naughty us! we really need to make sure the changelog is up to date