### PR TITLE
Attached source and javadoc artefacts to jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.5.0-RELEASE
+## 3.5.1-RELEASE
 * Attached source and javadoc artifacts to jar
 
 ## 3.5.0-RELEASE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 3.5.0-RELEASE
+* Attached source and javadoc artifacts to jar
+
+## 3.5.0-RELEASE
 * `Template` now contains `personalisation`, a map of the template placeholder names.
 
 ## 3.4.0-RELEASE

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>3.5.0-RELEASE</version>
+        <version>3.5.1-RELEASE</version>
     </dependency>
 
 ```
@@ -60,7 +60,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:3.5.0-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:3.5.1-RELEASE')
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.5.0-RELEASE</version>
+    <version>3.5.1-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>
@@ -61,6 +61,30 @@
             </resource>
         </resources>
     <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>attach-sources</id>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>attach-javadocs</id>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-project.version=3.5.0-RELEASE
+project.version=3.5.1-RELEASE

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -43,7 +43,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.5.0-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.5.1-RELEASE");
     }
 
     @Test


### PR DESCRIPTION
Attached the source and javadoc to the jar for better integration with
IDEs when using the jar as a library.

- Updated version to 3.5.1
- Added plugins to pom to attache source and javadoc