### PR TITLE
Added new sendSms method that takes a smsSenderId.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 3.7.0-RELEASE
+* Update to `NotificationsAPIClient.sendSms()`
+    * added `smsSenderId`: an optional smsSenderId specified when adding text message senders under service settings, if this is not provided the default text message sender for the service will be used. `smsSenderId` can be omitted.
+
 ## 3.6.0-RELEASE
-* Update to `NotificationsAPIClient.send_email_notification()`
-    * added `email_reply_to_id`: an optional email_reply_to_id specified when adding Email reply to addresses under service settings, if this is not provided the reply to email will be the service default reply to email. `email_reply_to_id` can be omitted.
+* Update to `NotificationsAPIClient.sendEmail()`
+    * added `emailReplyToId`: an optional email_reply_to_id specified when adding Email reply to addresses under service settings, if this is not provided the reply to email will be the service default reply to email. `emailReplyToId` can be omitted.
 
 ## 3.5.1-RELEASE
 * Attached source and javadoc artifacts to jar

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>3.6.0-RELEASE</version>
+        <version>3.7.0-RELEASE</version>
     </dependency>
 
 ```
@@ -85,7 +85,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:3.6.0-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:3.7.0-RELEASE')
 }
 ```
 </details>
@@ -186,6 +186,11 @@ personalisation.put("name", "Jo");
 personalisation.put("reference_number", "13566");
 ```
 
+#### `smsSenderId`
+Optional. Specifies the identifier of the text message sender to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Text message senders'.
+If you omit this argument your default text message sender will be for the notification.
+
+
 </details>
 
 ### Email
@@ -266,7 +271,7 @@ An optional identifier you generate. The reference can be used as a unique refer
 
 You can omit this argument if you do not require a reference for the notification.
 
-#### `email_reply_to_id`
+#### `emailReplyToId`
 Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'.
 If you omit this argument your default email reply-to address will be set for the notification.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.6.0-RELEASE</version>
+    <version>3.7.0-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -122,39 +122,10 @@ public class NotificationClient implements NotificationClientApi {
         return proxy;
     }
 
-    /**
-     * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
-     *
-     * @param templateId      Find templateId by clicking API info for the template you want to send
-     * @param emailAddress    The email address
-     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
-     *                        Can be an empty map or null when the template does not require placeholders.
-     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
-     *                        This reference can be unique or used used to refer to a batch of notifications.
-     *                        Can be an empty string or null, when you do not require a reference for the notifications.
-     * @return <code>SendEmailResponse</code>
-     * @throws NotificationClientException
-     */
     public SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, String> personalisation, String reference) throws NotificationClientException {
         return sendEmail(templateId, emailAddress, personalisation, reference, "");
     }
 
-    /**
-     * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
-     *
-     * @param templateId      Find templateId by clicking API info for the template you want to send
-     * @param emailAddress    The email address
-     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
-     *                        Can be an empty map or null when the template does not require placeholders.
-     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
-     *                        This reference can be unique or used used to refer to a batch of notifications.
-     *                        Can be an empty string or null, when you do not require a reference for the notifications.
-     * @param emailReplyToId  An optional identifier for a reply to email address for the notification, rather than use the service default.
-     *                        Service email_reply_to ids can be accessed via the service settings / manage email reply to addresses page.
-     *                        Omit this argument to use the default service email reply to address.
-     * @return <code>SendEmailResponse</code>
-     * @throws NotificationClientException
-     */
     @Override
     public SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, String> personalisation, String reference, String emailReplyToId) throws NotificationClientException {
         JSONObject body = createBodyForPostRequest(templateId, null, emailAddress, personalisation, reference);
@@ -169,43 +140,10 @@ public class NotificationClient implements NotificationClientApi {
         return new SendEmailResponse(response);
     }
 
-    /**
-     * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
-     *
-     * @param templateId      Find templateId by clicking API info for the template you want to send
-     * @param phoneNumber              The mobile phone number
-     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
-     *                        Can be an empty map or null when the template does not require placeholders.
-     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
-     *                        This reference can be unique or used used to refer to a batch of notifications.
-     *                        Can be an empty string or null, when you do not require a reference for the notifications.
-     * @return <code>SendSmsResponse</code>
-     * @throws NotificationClientException
-     */
     public SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference) throws NotificationClientException {
-        JSONObject body = createBodyForPostRequest(templateId, phoneNumber, null, personalisation, reference);
-        HttpURLConnection conn = createConnectionAndSetHeaders(baseUrl + "/v2/notifications/sms", "POST");
-        String response = performPostRequest(conn, body, HttpsURLConnection.HTTP_CREATED);
-        return new SendSmsResponse(response);
+        return sendSms(templateId, phoneNumber, personalisation, reference, "");
     }
 
-
-    /**
-     * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
-     *
-     * @param templateId      The template id is visible from the template page in the application.
-     * @param phoneNumber              The mobile phone number
-     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
-     *                        Can be an empty map or null when the template does not require placeholders.
-     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
-     *                        This reference can be unique or used used to refer to a batch of notifications.
-     *                        Can be an empty string or null, when you do not require a reference for the notifications.
-     * @param smsSenderId     An optional identifier for the text message sender of the notification, rather than use the service default.
-     *                        Service smsSenderIds can be accessed via the service settings / manage text message senders page.
-     *                        Omit this argument to use the default service text message sender.
-     * @return <code>SendSmsResponse</code>
-     * @throws NotificationClientException
-     */
     public SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference, String smsSenderId) throws NotificationClientException {
         JSONObject body = createBodyForPostRequest(templateId, phoneNumber, null, personalisation, reference);
         if( smsSenderId != null && !smsSenderId.isEmpty()){
@@ -216,18 +154,6 @@ public class NotificationClient implements NotificationClientApi {
         return new SendSmsResponse(response);
     }
 
-    /**
-     * The sendLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
-     *
-     * @param templateId      Find templateId by clicking API info for the template you want to send
-     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob.
-     *                        Must include the keys "address_line_1", "address_line_2" and "postcode".
-     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
-     *                        This reference can be unique or used used to refer to a batch of notifications.
-     *                        Can be an empty string or null, when you do not require a reference for the notifications.
-     * @return <code>SendLetterResponse</code>
-     * @throws NotificationClientException
-     */
     public SendLetterResponse sendLetter(String templateId, Map<String, String> personalisation, String reference) throws NotificationClientException {
         JSONObject body = createBodyForPostRequest(templateId, null, null, personalisation, reference);
         HttpURLConnection conn = createConnectionAndSetHeaders(baseUrl + "/v2/notifications/letter", "POST");
@@ -235,14 +161,6 @@ public class NotificationClient implements NotificationClientApi {
         return new SendLetterResponse(response);
     }
 
-    /**
-     * The getNotificationById method will return a <code>Notification</code> for a given notification id.
-     * The id is can be retrieved from the <code>NotificationResponse</code> of a <code>sendEmail</code> or <code>sendSms</code> request.
-     *
-     * @param notificationId The id of the notification.
-     * @return <code>Notification</code>
-     * @throws NotificationClientException
-     */
     public Notification getNotificationById(String notificationId) throws NotificationClientException {
         String url = baseUrl + "/v2/notifications/" + notificationId;
         HttpURLConnection conn = createConnectionAndSetHeaders(url, "GET");
@@ -251,18 +169,6 @@ public class NotificationClient implements NotificationClientApi {
 
     }
 
-    /**
-     * The getNotifications method will create a GET HTTPS request to retrieve all the notifications.
-     *
-     * @param status If status is not empty or null notifications will only return notifications for the given status.
-     *               Possible statuses are created|sending|delivered|permanent-failure|temporary-failure|technical-failure
-     * @param notification_type If notification_type is not empty or null only notifications of the given status will be returned.
-     *                          Possible notificationTypes are sms|email
-     * @param reference If reference is not empty or null only the notifications with that reference are returned.
-     * @param olderThanId If olderThanId is not empty or null only the notifications older than that notification id are returned.
-     * @return <code>NotificationList</code>
-     * @throws NotificationClientException
-     */
     public NotificationList getNotifications(String status, String notification_type, String reference, String olderThanId) throws NotificationClientException {
         try {
             URIBuilder builder = new URIBuilder(baseUrl + "/v2/notifications");
@@ -288,12 +194,6 @@ public class NotificationClient implements NotificationClientApi {
         }
     }
 
-    /**
-     * The getTemplateById returns a <code>Template</code> given the template id.
-     *
-     * @param templateId The template id is visible from the template page in the application.
-     * @return <code>Template</code>
-     */
     public Template getTemplateById(String templateId) throws NotificationClientException{
         String url = baseUrl + "/v2/template/" + templateId;
         HttpURLConnection conn = createConnectionAndSetHeaders(url, "GET");
@@ -301,15 +201,6 @@ public class NotificationClient implements NotificationClientApi {
         return new Template(response);
     }
 
-    /**
-     * The getTemplateVersion returns a <code>Template</code> given the template id and version.
-     *
-     *
-     * @param templateId The template id is visible from the template page in the application.
-     * @param version The version of the template to return
-     * @return <code>Template</code>
-     * @throws NotificationClientException
-     */
     public Template getTemplateVersion(String templateId, int version) throws NotificationClientException{
         String url = baseUrl + "/v2/template/" + templateId + "/version/" + version;
         HttpURLConnection conn = createConnectionAndSetHeaders(url, "GET");
@@ -317,14 +208,6 @@ public class NotificationClient implements NotificationClientApi {
         return new Template(response);
     }
 
-    /**
-     * Returns all the templates for your service. Filtered by template type if not null.
-     *
-     * @param templateType If templateType is not empty or null templates will be filtered by type.
-     *          Possible template types are email|sms|letter
-     * @return <code>TemplateList</code>
-     * @throws NotificationClientException
-     */
     public TemplateList getAllTemplates(String templateType) throws NotificationClientException{
         try{
             URIBuilder builder = new URIBuilder(baseUrl + "/v2/templates");
@@ -340,15 +223,6 @@ public class NotificationClient implements NotificationClientApi {
         }
     }
 
-    /**
-     * The generateTemplatePreview returns a template with the placeholders replaced with the given personalisation.
-     *
-     * @param templateId The template id is visible from the template page in the application.
-     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
-     *                        Can be an empty map or null when the template does not require placeholders.
-     * @return <code>TemplatePreview</code>
-     * @throws NotificationClientException
-     */
     public TemplatePreview generateTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException {
         JSONObject body = new JSONObject();
         if (personalisation != null && !personalisation.isEmpty()) {

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -191,6 +191,32 @@ public class NotificationClient implements NotificationClientApi {
 
 
     /**
+     * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param templateId      The template id is visible from the template page in the application.
+     * @param phoneNumber              The mobile phone number
+     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
+     *                        Can be an empty map or null when the template does not require placeholders.
+     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
+     *                        This reference can be unique or used used to refer to a batch of notifications.
+     *                        Can be an empty string or null, when you do not require a reference for the notifications.
+     * @param smsSenderId     An optional identifier for the text message sender of the notification, rather than use the service default.
+     *                        Service smsSenderIds can be accessed via the service settings / manage text message senders page.
+     *                        Omit this argument to use the default service text message sender.
+     * @return <code>SendSmsResponse</code>
+     * @throws NotificationClientException
+     */
+    public SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference, String smsSenderId) throws NotificationClientException {
+        JSONObject body = createBodyForPostRequest(templateId, phoneNumber, null, personalisation, reference);
+        if( !smsSenderId.isEmpty()){
+            body.put("sms_sender_id", smsSenderId);
+        }
+        HttpURLConnection conn = createConnectionAndSetHeaders(baseUrl + "/v2/notifications/sms", "POST");
+        String response = performPostRequest(conn, body, HttpsURLConnection.HTTP_CREATED);
+        return new SendSmsResponse(response);
+    }
+
+    /**
      * The sendLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
      * @param templateId      Find templateId by clicking API info for the template you want to send

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -159,7 +159,7 @@ public class NotificationClient implements NotificationClientApi {
     public SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, String> personalisation, String reference, String emailReplyToId) throws NotificationClientException {
         JSONObject body = createBodyForPostRequest(templateId, null, emailAddress, personalisation, reference);
 
-        if(!emailReplyToId.isEmpty())
+        if(emailReplyToId != null && !emailReplyToId.isEmpty())
         {
             body.put("email_reply_to_id", emailReplyToId);
         }
@@ -208,7 +208,7 @@ public class NotificationClient implements NotificationClientApi {
      */
     public SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference, String smsSenderId) throws NotificationClientException {
         JSONObject body = createBodyForPostRequest(templateId, phoneNumber, null, personalisation, reference);
-        if( !smsSenderId.isEmpty()){
+        if( smsSenderId != null && !smsSenderId.isEmpty()){
             body.put("sms_sender_id", smsSenderId);
         }
         HttpURLConnection conn = createConnectionAndSetHeaders(baseUrl + "/v2/notifications/sms", "POST");

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -54,6 +54,24 @@ public interface NotificationClientApi {
     SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference) throws NotificationClientException;
 
     /**
+     * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param templateId      The template id is visible from the template page in the application.
+     * @param phoneNumber              The mobile phone number
+     * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
+     *                        Can be an empty map or null when the template does not require placeholders.
+     * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
+     *                        This reference can be unique or used used to refer to a batch of notifications.
+     *                        Can be an empty string or null, when you do not require a reference for the notifications.
+     * @param smsSenderId     An optional identifier for the text message sender of the notification, rather than use the service default.
+     *                        Service smsSenderIds can be accessed via the service settings / manage text message senders page.
+     *                        Omit this argument to use the default service text message sender.
+     * @return <code>SendSmsResponse</code>
+     * @throws NotificationClientException
+     */
+    SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference, String smsSenderId) throws NotificationClientException;
+
+    /**
      * The sendLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
      * @param templateId      Find templateId by clicking API info for the template you want to send

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -31,7 +31,7 @@ public interface NotificationClientApi {
      *                        This reference can be unique or used used to refer to a batch of notifications.
      *                        Can be an empty string or null, when you do not require a reference for the notifications.
      * @param emailReplyToId  An optional identifier for a reply to email address for the notification, rather than use the service default.
-     *                        Service email_reply_to ids can be accessed via the service settings / manage email reply to addresses page.
+     *                        Service emailReplyToIds can be accessed via the service settings / manage email reply to addresses page.
      *                        Omit this argument to use the default service email reply to address.
      * @return <code>SendEmailResponse</code>
      * @throws NotificationClientException
@@ -42,7 +42,7 @@ public interface NotificationClientApi {
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
      * @param templateId      The template id is visible from the template page in the application.
-     * @param phoneNumber              The mobile phone number
+     * @param phoneNumber     The mobile phone number
      * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
      *                        Can be an empty map or null when the template does not require placeholders.
      * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
@@ -57,7 +57,7 @@ public interface NotificationClientApi {
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
      *
      * @param templateId      The template id is visible from the template page in the application.
-     * @param phoneNumber              The mobile phone number
+     * @param phoneNumber     The mobile phone number
      * @param personalisation Map representing the placeholders for the template if any. For example, key=name value=Bob
      *                        Can be an empty map or null when the template does not require placeholders.
      * @param reference       A reference specified by the service for the notification. Get all notifications can be filtered by this reference.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.6.0-RELEASE
+project.version=3.7.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -75,6 +75,60 @@ public class ClientIntegrationTestIT {
     }
 
     @Test
+    public void testEmailNotificationWithValidEmailReplyToIdIT() throws NotificationClientException, InterruptedException {
+        NotificationClient client = getClient();
+        SendEmailResponse emailResponse = sendEmailAndAssertResponse(client);
+
+        HashMap<String, String> personalisation = new HashMap<>();
+        String uniqueName = UUID.randomUUID().toString();
+        personalisation.put("name", uniqueName);
+
+        SendEmailResponse response = client.sendEmail(
+                System.getenv("EMAIL_TEMPLATE_ID"),
+                System.getenv("FUNCTIONAL_TEST_EMAIL"),
+                personalisation,
+                uniqueName,
+                System.getenv("EMAIL_REPLY_TO_ID"));
+
+        assertNotificationEmailResponse(response, uniqueName);
+
+        Notification notification = client.getNotificationById(emailResponse.getNotificationId().toString());
+        assertNotification(notification);
+    }
+
+    @Test
+    public void testEmailNotificationWithInValidEmailReplyToIdIT() throws NotificationClientException, InterruptedException {
+        NotificationClient client = getClient();
+        SendEmailResponse emailResponse = sendEmailAndAssertResponse(client);
+
+        HashMap<String, String> personalisation = new HashMap<>();
+        String uniqueName = UUID.randomUUID().toString();
+        personalisation.put("name", uniqueName);
+
+        UUID fake_uuid = UUID.randomUUID();
+
+        boolean exceptionThrown = false;
+
+        try
+        {
+            SendEmailResponse response = client.sendEmail(
+                    System.getenv("EMAIL_TEMPLATE_ID"),
+                    System.getenv("FUNCTIONAL_TEST_EMAIL"),
+                    personalisation,
+                    uniqueName,
+                    fake_uuid.toString());
+        }
+        catch (final NotificationClientException ex)
+        {
+            exceptionThrown = true;
+            assertTrue(ex.getMessage().toString().contains("does not exist in database for service id"));
+        }
+
+        assertTrue(exceptionThrown);
+
+    }
+
+    @Test
     public void testSmsNotificationWithoutPersonalisationReturnsErrorMessageIT() {
         NotificationClient client = getClient();
         try {
@@ -84,6 +138,58 @@ public class ClientIntegrationTestIT {
             assert(e.getMessage().contains("Missing personalisation: name"));
             assert(e.getMessage().contains("Status code: 400"));
         }
+    }
+
+    @Test
+    public void testSmsNotificationWithValidSmsSenderIdIT() throws NotificationClientException, InterruptedException {
+        NotificationClient client = getClient();
+
+        HashMap<String, String> personalisation = new HashMap<>();
+        String uniqueName = UUID.randomUUID().toString();
+        personalisation.put("name", uniqueName);
+
+        SendSmsResponse response = client.sendSms(
+                System.getenv("SMS_TEMPLATE_ID"),
+                System.getenv("FUNCTIONAL_TEST_NUMBER"),
+                personalisation,
+                uniqueName,
+                System.getenv("SMS_SENDER_ID"));
+
+        assertNotificationSmsResponse(response, uniqueName);
+
+        Notification notification = client.getNotificationById(response.getNotificationId().toString());
+        assertNotification(notification);
+    }
+
+    @Test
+    public void testSmsNotificationWithInValidSmsSenderIdIT() throws NotificationClientException, InterruptedException {
+        NotificationClient client = getClient();
+
+        HashMap<String, String> personalisation = new HashMap<>();
+        String uniqueName = UUID.randomUUID().toString();
+        personalisation.put("name", uniqueName);
+
+        UUID fake_uuid = UUID.randomUUID();
+
+        boolean exceptionThrown = false;
+
+        try
+        {
+            SendSmsResponse response = client.sendSms(
+                    System.getenv("SMS_TEMPLATE_ID"),
+                    System.getenv("FUNCTIONAL_TEST_NUMBER"),
+                    personalisation,
+                    uniqueName,
+                    fake_uuid.toString());
+        }
+        catch (final NotificationClientException ex)
+        {
+            exceptionThrown = true;
+            assertTrue(ex.getMessage().toString().contains("does not exist in database for service id"));
+        }
+
+        assertTrue(exceptionThrown);
+
     }
 
     @Test
@@ -278,60 +384,5 @@ public class ClientIntegrationTestIT {
         assertFalse(notification.getLine6().isPresent());
         assertFalse(notification.getPostcode().isPresent());
     }
-
-    @Test
-    public void testEmailNotificationWithValidEmailReplyToIdIT() throws NotificationClientException, InterruptedException {
-        NotificationClient client = getClient();
-        SendEmailResponse emailResponse = sendEmailAndAssertResponse(client);
-
-        HashMap<String, String> personalisation = new HashMap<>();
-        String uniqueName = UUID.randomUUID().toString();
-        personalisation.put("name", uniqueName);
-
-        SendEmailResponse response = client.sendEmail(
-                System.getenv("EMAIL_TEMPLATE_ID"),
-                System.getenv("FUNCTIONAL_TEST_EMAIL"),
-                personalisation,
-                uniqueName,
-                System.getenv("EMAIL_REPLY_TO_ID"));
-
-        assertNotificationEmailResponse(response, uniqueName);
-
-        Notification notification = client.getNotificationById(emailResponse.getNotificationId().toString());
-        assertNotification(notification);
-    }
-
-    @Test
-    public void testEmailNotificationWithInValidEmailReplyToIdIT() throws NotificationClientException, InterruptedException {
-        NotificationClient client = getClient();
-        SendEmailResponse emailResponse = sendEmailAndAssertResponse(client);
-
-        HashMap<String, String> personalisation = new HashMap<>();
-        String uniqueName = UUID.randomUUID().toString();
-        personalisation.put("name", uniqueName);
-
-        UUID fake_uuid = UUID.randomUUID();
-
-        boolean exceptionThrown = false;
-
-        try
-        {
-            SendEmailResponse response = client.sendEmail(
-                    System.getenv("EMAIL_TEMPLATE_ID"),
-                    System.getenv("FUNCTIONAL_TEST_EMAIL"),
-                    personalisation,
-                    uniqueName,
-                    fake_uuid.toString());
-        }
-        catch (final NotificationClientException ex)
-        {
-            exceptionThrown = true;
-            assertTrue(ex.getMessage().toString().contains("does not exist in database for service id"));
-        }
-
-        assertTrue(exceptionThrown);
-
-    }
-
 
 }

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -43,7 +43,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.6.0-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.7.0-RELEASE");
     }
 
     @Test


### PR DESCRIPTION
A new sendSms() that takes an optional parameter smsSenderId. 

If the smsSenderId is set that sms sender will be used as the from number for the SMS notification, otherwise the default sms sender for the notification will be used. 

The smsSenderId can be found on the service setting page, in the "Text message senders" section.