### PR TITLE
Update the integration test to look for the right status.

### DIFF
--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -376,7 +376,7 @@ public class ClientIntegrationTestIT {
         }
 
         if(notification.getNotificationType().equals("letter")){
-            assertEquals("accepted", notification.getStatus());
+            assertEquals("received", notification.getStatus());
         } else {
             assertTrue("expected status to be created, sending or delivered", Arrays.asList("created", "sending", "delivered").contains(notification.getStatus()));
         }


### PR DESCRIPTION
When a letter is created with a test api key the status of the notification is set to delivered.
