### PR TITLE
The API has been updated so that the precompiled response to only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.1-RELEASE
+* Response to `sendPrecompiledLetter` updated
+  - The response now only includes the notification id and the client reference
+
 ## 3.9.0-RELEASE
 * `sendPrecompiledLetter` added to NotificationClient
   - The client can now send PDF files which conform to the Notify printing template

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ An optional unique identifier for the notification or an identifier for a batch 
 
 ### Precompiled Letter
 
+This is an invitation only feature, for more information contact us via[https://www.notifications.service.gov.uk/support](https://www.notifications.service.gov.uk/support).
+
 #### Method
 
 The letter must contain:
@@ -387,17 +389,6 @@ SendLetterResponse response = client.sendPrecompiledLetter("Your reference", pre
 ```
 </details>
 
-<details>
-<summary>
-Base64 Ecoded String - Click here to expand for more information.
-</summary>
-
-```java
-String base64EncodedPDFFile = "<base64 encoded string of a file>";
-SendLetterResponse response = client.SendLetterResponse sendPrecompiledLetter("Your reference", base64EncodedPDFFile);
-```
-</details>
-
 #### Response
 
 If the request is successful, the SendLetterResponse is returned from the client. Attributes of the SendLetterResponse are listed below.
@@ -409,12 +400,7 @@ Click here to expand for more information.
 
 ```java
 	UUID notificationId;
-	Optional<String> reference;
-	UUID templateId;
-	int templateVersion;
-	String templateUri;
-	String body (for recompiled letters this is always null);
-	String subject;
+	<String> reference;
 ```
 
 Otherwise the client will raise a `NotificationClientException`:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>3.9.0-RELEASE</version>
+        <version>3.9.1-RELEASE</version>
     </dependency>
 
 ```
@@ -83,7 +83,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:3.9.0-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:3.9.1-RELEASE')
 }
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -384,14 +384,14 @@ Java File Object - Click here to expand for more information.
 
 ```java
 File precompiledPDF = new File("<path to your file>");
-SendLetterResponse response = client.sendPrecompiledLetter("Your reference", precompiledPDF)
+LetterResponse response = client.sendPrecompiledLetter("Your reference", precompiledPDF)
 
 ```
 </details>
 
 #### Response
 
-If the request is successful, the SendLetterResponse is returned from the client. Attributes of the SendLetterResponse are listed below.
+If the request is successful, the LetterResponse is returned from the client. Attributes of the LetterResponse are listed below.
 
 <details>
 <summary>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.9.0-RELEASE</version>
+    <version>3.9.1-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/uk/gov/service/notify/LetterResponse.java
+++ b/src/main/java/uk/gov/service/notify/LetterResponse.java
@@ -1,0 +1,56 @@
+package uk.gov.service.notify;
+
+import org.json.JSONObject;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class LetterResponse {
+    private UUID notificationId;
+    private String reference;
+    private JSONObject data;
+
+    public LetterResponse(String response) {
+        data = new JSONObject(response);
+        notificationId = UUID.fromString(data.getString("id"));
+        reference = data.isNull("reference") ? null : data.getString("reference");
+
+    }
+
+    public UUID getNotificationId() {
+        return notificationId;
+    }
+
+    public Optional<String> getReference() {
+        return Optional.ofNullable(reference);
+    }
+
+    public JSONObject getData() {
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        return "SendLetterResponse{" +
+                "notificationId=" + notificationId +
+                ", reference=" + reference +
+                '}';
+    }
+
+    public String tryToGetString(JSONObject jsonObj, String key)
+    {
+        if (jsonObj.has(key))
+        {
+            if(jsonObj.opt(key).toString().equals("null"))
+            {
+                return null;
+            }
+            else
+            {
+                return jsonObj.opt(key).toString();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -463,7 +463,7 @@ public class NotificationClient implements NotificationClientApi {
         return prop.getProperty("project.version");
     }
 
-    private SendLetterResponse sendPrecompiledLetter(String reference, String base64EncodedPDFFile) throws NotificationClientException
+    private LetterResponse sendPrecompiledLetter(String reference, String base64EncodedPDFFile) throws NotificationClientException
     {
         if( StringUtils.isBlank(reference) )
         {
@@ -493,7 +493,7 @@ public class NotificationClient implements NotificationClientApi {
         );
 
         String response = performPostRequest(conn, body, HttpsURLConnection.HTTP_CREATED);
-        return new SendLetterResponse(response);
+        return new LetterResponse(response);
 
     }
 

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -498,7 +498,7 @@ public class NotificationClient implements NotificationClientApi {
     }
 
     @Override
-    public SendLetterResponse sendPrecompiledLetter(String reference, File precompiledPDF) throws NotificationClientException
+    public LetterResponse sendPrecompiledLetter(String reference, File precompiledPDF) throws NotificationClientException
     {
 
         if (precompiledPDF == null)

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -21,7 +21,7 @@ import org.json.JSONObject;
 public class NotificationClient implements NotificationClientApi {
 
     private static final Logger LOGGER = Logger.getLogger(NotificationClient.class.toString());
-    public static final String LIVE_BASE_URL = "https://api.notifications.service.gov.uk";
+    private static final String LIVE_BASE_URL = "https://api.notifications.service.gov.uk";
 
     private final String apiKey;
     private final String serviceId;
@@ -57,7 +57,7 @@ public class NotificationClient implements NotificationClientApi {
     /**
      * This client constructor is used for testing on other environments, used by the GOV.UK Notify team.
      * @param apiKey Generate an API key by signing in to GOV.UK Notify, https://www.notifications.service.gov.uk, and going to the **API integration** page
-     * @param baseUrl
+     * @param baseUrl base URL, defaults to https://api.notifications.service.gov.uk
      */
     public NotificationClient(final String apiKey, final String baseUrl) {
         this(
@@ -72,7 +72,7 @@ public class NotificationClient implements NotificationClientApi {
      *
      * @param apiKey Generate an API key by signing in to GOV.UK Notify, https://www.notifications.service.gov.uk, and going to the **API integration** page
      * @param baseUrl base URL, defaults to https://api.notifications.service.gov.uk
-     * @param proxy
+     * @param proxy Proxy used on the http requests
      */
     public NotificationClient(final String apiKey, final String baseUrl, final Proxy proxy) {
         this(
@@ -463,8 +463,7 @@ public class NotificationClient implements NotificationClientApi {
         return prop.getProperty("project.version");
     }
 
-    @Override
-    public SendLetterResponse sendPrecompiledLetter(String reference, String base64EncodedPDFFile) throws NotificationClientException
+    private SendLetterResponse sendPrecompiledLetter(String reference, String base64EncodedPDFFile) throws NotificationClientException
     {
         if( StringUtils.isBlank(reference) )
         {

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -92,27 +92,13 @@ public interface NotificationClientApi {
      * @param reference                 A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
      *                                  This reference can be unique or used used to refer to a batch of notifications.
      *                                  Cannot be an empty string or null for precompiled PDF files.
-     * @param base64EncodedPDFFile      A string containing a base64 encoded string containing a PDF conforming to the Notify standards for printing.
-     *                                  The String cannot be null or empty.
-     * @return <code>SendLetterResponse</code>
-     *
-     * @throws NotificationClientException
-     */
-    SendLetterResponse sendPrecompiledLetter(String reference, String base64EncodedPDFFile) throws NotificationClientException;
-
-    /**
-     * The sendPrecompiledLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
-     *
-     * @param reference                 A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
-     *                                  This reference can be unique or used used to refer to a batch of notifications.
-     *                                  Cannot be an empty string or null for precompiled PDF files.
      * @param precompiledPDF            A file containing a PDF conforming to the Notify standards for printing.
      *                                  The file must be a PDF and cannot be null.
      * @return <code>SendLetterResponse</code>
      *
      * @throws NotificationClientException
      */
-    SendLetterResponse sendPrecompiledLetter(String reference, File precompiledPDF) throws NotificationClientException;
+    LetterResponse sendPrecompiledLetter(String reference, File precompiledPDF) throws NotificationClientException;
 
     /**
      * The getNotificationById method will return a <code>Notification</code> for a given notification id.

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -94,7 +94,7 @@ public interface NotificationClientApi {
      *                                  Cannot be an empty string or null for precompiled PDF files.
      * @param precompiledPDF            A file containing a PDF conforming to the Notify standards for printing.
      *                                  The file must be a PDF and cannot be null.
-     * @return <code>SendLetterResponse</code>
+     * @return <code>LetterResponse</code>
      *
      * @throws NotificationClientException
      */

--- a/src/main/java/uk/gov/service/notify/SendLetterResponse.java
+++ b/src/main/java/uk/gov/service/notify/SendLetterResponse.java
@@ -5,35 +5,25 @@ import org.json.JSONObject;
 import java.util.Optional;
 import java.util.UUID;
 
-public class SendLetterResponse {
-    private UUID notificationId;
-    private String reference;
+public class SendLetterResponse extends LetterResponse {
     private UUID templateId;
     private int templateVersion;
     private String templateUri;
     private String body;
     private String subject;
+    private JSONObject content;
+    private JSONObject template;
 
 
     public SendLetterResponse(String response) {
-        JSONObject data = new JSONObject(response);
-        notificationId = UUID.fromString(data.getString("id"));
-        reference = data.isNull("reference") ? null : data.getString("reference");
-        JSONObject content = data.getJSONObject("content");
+        super(response);
+        content = getData().getJSONObject("content");
         body = tryToGetString(content, "body");
         subject = tryToGetString(content, "subject");
-        JSONObject template = data.getJSONObject("template");
+        template = getData().getJSONObject("template");
         templateId = UUID.fromString(template.getString("id"));
         templateVersion = template.getInt("version");
         templateUri = template.getString("uri");
-    }
-
-    public UUID getNotificationId() {
-        return notificationId;
-    }
-
-    public Optional<String> getReference() {
-        return Optional.ofNullable(reference);
     }
 
     public UUID getTemplateId() {
@@ -59,30 +49,13 @@ public class SendLetterResponse {
     @Override
     public String toString() {
         return "SendLetterResponse{" +
-                "notificationId=" + notificationId +
-                ", reference=" + reference +
+                "notificationId=" + getNotificationId() +
+                ", reference=" + getReference() +
                 ", templateId=" + templateId +
                 ", templateVersion=" + templateVersion +
                 ", templateUri='" + templateUri + '\'' +
                 ", body='" + body + '\'' +
                 ", subject='" + subject +
                 '}';
-    }
-
-    private String tryToGetString(JSONObject jsonObj, String key)
-    {
-        if (jsonObj.has(key))
-        {
-            if(jsonObj.opt(key).toString() == "null")
-            {
-                return null;
-            }
-            else
-            {
-                return jsonObj.opt(key).toString();
-            }
-        }
-
-        return null;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.9.0-RELEASE
+project.version=3.9.1-RELEASE

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -125,7 +125,7 @@ public class ClientIntegrationTestIT {
         catch (final NotificationClientException ex)
         {
             exceptionThrown = true;
-            assertTrue(ex.getMessage().toString().contains("does not exist in database for service id"));
+            assertTrue(ex.getMessage().contains("does not exist in database for service id"));
         }
 
         assertTrue(exceptionThrown);
@@ -189,7 +189,7 @@ public class ClientIntegrationTestIT {
         catch (final NotificationClientException ex)
         {
             exceptionThrown = true;
-            assertTrue(ex.getMessage().toString().contains("does not exist in database for service id"));
+            assertTrue(ex.getMessage().contains("does not exist in database for service id"));
         }
 
         assertTrue(exceptionThrown);
@@ -436,43 +436,9 @@ public class ClientIntegrationTestIT {
 
     }
 
-    @Test
-    public void testSendPrecompiledLetterValidPDFFileBase64StringIT() throws Exception {
-
-        String reference = UUID.randomUUID().toString();
-
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("one_page_pdf.pdf").getFile());
-
-        byte[] encoded = Base64.encodeBase64(FileUtils.readFileToByteArray(file));
-        String base64encodedString = new String(encoded, StandardCharsets.US_ASCII);
-
-        NotificationClient client = getClient();
-        SendLetterResponse response = client.sendPrecompiledLetter(
-                reference,
-                base64encodedString
-        );
-
-        assertPrecompiledLetterResponse(reference, response);
-    }
-
-    @Test(expected=NotificationClientException.class)
-    public void testSendPrecompiledLetterValidPDFBase64StringNotPDFDFileIT() throws Exception {
-        String reference = UUID.randomUUID().toString();
-
-        NotificationClient client = getClient();
-        SendLetterResponse response =  client.sendPrecompiledLetter(reference,
-                "qwertyuiopqwertyuiopqwertyuiopqwertyuiop");
-    }
-
     private void assertPrecompiledLetterResponse(String reference, SendLetterResponse response) {
         assertNotNull(response);
         assertNotNull(response.getNotificationId());
-        assertNotNull(response.getTemplateVersion());
-        assertNotNull(response.getTemplateId());
-        assertNotNull(response.getTemplateUri());
-        assertNotNull(response.getTemplateVersion());
-        assertNotNull(response.getReference().get());
         assertEquals(response.getReference().get(), reference);
     }
 

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -430,13 +430,13 @@ public class ClientIntegrationTestIT {
         ClassLoader classLoader = getClass().getClassLoader();
         File file = new File(classLoader.getResource("one_page_pdf.pdf").getFile());
         NotificationClient client = getClient();
-        SendLetterResponse response =  client.sendPrecompiledLetter(reference, file);
+        LetterResponse response =  client.sendPrecompiledLetter(reference, file);
 
         assertPrecompiledLetterResponse(reference, response);
 
     }
 
-    private void assertPrecompiledLetterResponse(String reference, SendLetterResponse response) {
+    private void assertPrecompiledLetterResponse(String reference, LetterResponse response) {
         assertNotNull(response);
         assertNotNull(response.getNotificationId());
         assertEquals(response.getReference().get(), reference);

--- a/src/test/java/uk/gov/service/notify/LetterResponseTest.java
+++ b/src/test/java/uk/gov/service/notify/LetterResponseTest.java
@@ -1,0 +1,36 @@
+package uk.gov.service.notify;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+public class LetterResponseTest {
+
+    @Test
+    public void testNotificationResponseForLetterResponse(){
+        JSONObject postLetterResponse = new JSONObject();
+        UUID id = UUID.randomUUID();
+        postLetterResponse.put("id", id);
+        postLetterResponse.put("reference", "clientReference");
+
+        LetterResponse response = new LetterResponse(postLetterResponse.toString());
+        assertEquals(id, response.getNotificationId());
+        assertEquals(Optional.of("clientReference"), response.getReference());
+    }
+
+    @Test
+    public void testNotificationResponseForPrecompiledLetterResponse(){
+        String precompiledPdfResponse = "{\n" +
+                "  \"id\": \"5f88e576-c97a-4262-a74b-f558882ca1c8\", \n" +
+                "  \"reference\": \"reference\"\n" +
+                "}";
+
+        LetterResponse response = new LetterResponse(precompiledPdfResponse);
+        assertEquals("5f88e576-c97a-4262-a74b-f558882ca1c8", response.getNotificationId().toString());
+        assertEquals(Optional.of("reference"), response.getReference());
+    }
+}

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -74,33 +74,9 @@ public class NotificationClientTest {
     }
 
     @Test(expected = NotificationClientException.class)
-    public void sendPrecompiledLetterReferenceIsNull() throws Exception {
-        NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        client.sendPrecompiledLetter(null, "this is a string");
-    }
-
-    @Test(expected = NotificationClientException.class)
-    public void sendPrecompiledLetterReferenceIsEmpty() throws Exception {
-        NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        client.sendPrecompiledLetter(" ", "this is a string");
-    }
-
-    @Test(expected = NotificationClientException.class)
     public void sendPrecompiledLetterBase64EncodedPDFFileIsNull() throws Exception {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        client.sendPrecompiledLetter("reference", (File)null);
-    }
-
-    @Test(expected = NotificationClientException.class)
-    public void sendPrecompiledLetterBase64EncodedPDFFileIsStringNull() throws Exception {
-        NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        client.sendPrecompiledLetter("reference", (String)null);
-    }
-
-    @Test(expected = NotificationClientException.class)
-    public void sendPrecompiledLetterBase64EncodedPDFFileIsEmpty() throws Exception {
-        NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        client.sendPrecompiledLetter("reference", " ");
+        client.sendPrecompiledLetter("reference", null);
     }
 
     @Test(expected = NotificationClientException.class)
@@ -109,15 +85,5 @@ public class NotificationClientTest {
         File file = new File(classLoader.getResource("not_a_pdf.txt").getFile());
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
         client.sendPrecompiledLetter("reference", file);
-    }
-
-    @Test(expected = NotificationClientException.class)
-    public void sendPrecompiledLetterBase64StringNotPDF() throws Exception {
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("not_a_pdf.txt").getFile());
-        byte[] encoded = Base64.encodeBase64(FileUtils.readFileToByteArray(file));
-        String base64encodedString = new String(encoded, StandardCharsets.US_ASCII);
-        NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        client.sendPrecompiledLetter("reference", base64encodedString);
     }
 }

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -48,7 +48,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.9.0-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.9.1-RELEASE");
     }
 
     @Test


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
The API has been updated so that the precompiled response to only includes the notification id and the client reference. Also removed the base64String method as it depends on how the base64 string is encoded so it is better that we do the encoding and have control of that.

* Added code to handle the different LetterResponse
* Updated Readme
* Updated the unit and integration tests
* A few code analysis updated

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `README.md`)
- [x] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
