### PR TITLE
Fix letter status for integration tests.

### DIFF
--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -380,7 +380,7 @@ public class ClientIntegrationTestIT {
         }
 
         if(notification.getNotificationType().equals("letter")){
-            assertEquals("received", notification.getStatus());
+            assertTrue("expected status to be accepted or received", Arrays.asList("accepted", "received").contains(notification.getStatus()));
         } else {
             assertTrue("expected status to be created, sending or delivered", Arrays.asList("created", "sending", "delivered").contains(notification.getStatus()));
         }


### PR DESCRIPTION
When sending a letter with a test api key, a fake response will be created if the integration tests are running in Preview or Dev environment.

Usually the letter will still have a status of accepted, but it is possible the response file has processed and the notification has been updated to received.
Update the test to accept either status.

No need to update the version or change log for this change.
