### PR TITLE
Updated testEmailNotificationWithoutPersonalisationReturnsErrorMessageIT to remove the check which depends on a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.9.2-RELEASE
+* Updated testEmailNotificationWithoutPersonalisationReturnsErrorMessageIT to only look for the BadRequestError rather than the json "error": BadRequestError
+
 ## 3.9.1-RELEASE
 * Response to `sendPrecompiledLetter` updated
   - The response now only includes the notification id and the client reference

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -64,7 +64,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>3.9.1-RELEASE</version>
+        <version>3.9.2-RELEASE</version>
     </dependency>
 
 ```
@@ -83,7 +83,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:3.9.1-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:3.9.2-RELEASE')
 }
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Then add the Maven dependency to your project.
     <dependency>
         <groupId>uk.gov.service.notify</groupId>
         <artifactId>notifications-java-client</artifactId>
-        <version>3.9.1-RELEASE</version>
+        <version>3.9.2-RELEASE</version>
     </dependency>
 
 ```
@@ -83,7 +83,7 @@ repositories {
 }
 
 dependencies {
-    compile('uk.gov.service.notify:notifications-java-client:3.9.1-RELEASE')
+    compile('uk.gov.service.notify:notifications-java-client:3.9.2-RELEASE')
 }
 ```
 </details>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.9.1-RELEASE</version>
+    <version>3.9.2-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.9.1-RELEASE
+project.version=3.9.2-RELEASE

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -74,7 +74,7 @@ public class ClientIntegrationTestIT {
         } catch (NotificationClientException e) {
             assert(e.getMessage().contains("Missing personalisation: name"));
             assert e.getHttpResult() == 400;
-            assert(e.getMessage().contains(" \"error\": \"BadRequestError\""));
+            assert(e.getMessage().contains("BadRequestError"));
         }
     }
 

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -48,7 +48,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.9.1-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.9.2-RELEASE");
     }
 
     @Test


### PR DESCRIPTION
testEmailNotificationWithoutPersonalisationReturnsErrorMessageIT was failing as it was checking for an occurrence of a space but now there is no space so have updated the test to only look for the BadRequestError string rather than the json "error": "BadRequestError"

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `README.md`)
- [x] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
