### PR TITLE
Added createdByName to Notification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.10.0-RELEASE
+* Updated `Notification` to have an Optional createdByName. If the notification was sent manually, this will be the name of the sender. If the notification was uploaded as a CSV or was sent through the API, this will be `Optional.empty()`.
+
 ## 3.9.2-RELEASE
 * Updated testEmailNotificationWithoutPersonalisationReturnsErrorMessageIT to only look for the BadRequestError rather than the json "error": BadRequestError
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.10.0-RELEASE
-* Updated `Notification` to have an Optional createdByName. If the notification was sent manually, this will be the name of the sender. If the notification was uploaded as a CSV or was sent through the API, this will be `Optional.empty()`.
+* Updated `Notification` to have an Optional createdByName. If the notification was sent manually, this will be the name of the sender. If the notification was sent through the API, this will be `Optional.empty()`.
 
 ## 3.9.2-RELEASE
 * Updated testEmailNotificationWithoutPersonalisationReturnsErrorMessageIT to only look for the BadRequestError rather than the json "error": BadRequestError

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -440,7 +440,7 @@ The ID of the notification.
 
 ### Response
 
-If the request to the client is successful, the client will return a `notification`:
+If the request to the client is successful, the client will return a `Notification`:
 
 ```java
 UUID id;
@@ -465,6 +465,7 @@ DateTime createdAt;
 Optional<DateTime> sentAt;
 Optional<DateTime> completedAt;
 Optional<DateTime> estimatedDelivery;
+Optional<String> createdByName;
 ```
 
 ### Error codes

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.9.2-RELEASE</version>
+    <version>3.10.0-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/uk/gov/service/notify/Notification.java
+++ b/src/main/java/uk/gov/service/notify/Notification.java
@@ -29,6 +29,7 @@ public class Notification {
     private DateTime sentAt;
     private DateTime completedAt;
     private DateTime estimatedDelivery;
+    private String createdByName;
 
     public Notification(String content){
         JSONObject responseBodyAsJson = new JSONObject(content);
@@ -63,6 +64,7 @@ public class Notification {
         sentAt =  data.isNull("sent_at") ? null : new DateTime(data.getString("sent_at"));
         completedAt = data.isNull("completed_at") ? null : new DateTime(data.getString("completed_at"));
         estimatedDelivery = data.isNull("estimated_delivery") ? null : new DateTime(data.getString("estimated_delivery"));
+        createdByName = data.isNull("created_by_name") ? null : data.getString("created_by_name");
     }
 
     public UUID getId() {
@@ -149,6 +151,10 @@ public class Notification {
         return Optional.ofNullable(completedAt);
     }
 
+    public Optional<String> getCreatedByName() {
+        return Optional.ofNullable(createdByName);
+    }
+
     /**
      * estimatedDelivery is only present on letters
      */
@@ -181,6 +187,7 @@ public class Notification {
                 ", sentAt=" + sentAt +
                 ", completedAt=" + completedAt +
                 ", estimatedDelivery=" + estimatedDelivery +
+                ", createdByName=" + createdByName +
                 '}';
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.9.2-RELEASE
+project.version=3.10.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -369,6 +369,7 @@ public class ClientIntegrationTestIT {
         assertNotNull(notification.getCreatedAt());
         assertNotNull(notification.getStatus());
         assertNotNull(notification.getNotificationType());
+        assertFalse(notification.getCreatedByName().isPresent());
         if(notification.getNotificationType().equals("sms")) {
             assertNotificationWhenSms(notification);
         }

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -48,7 +48,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.9.2-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.10.0-RELEASE");
     }
 
     @Test

--- a/src/test/java/uk/gov/service/notify/NotificationTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationTest.java
@@ -40,6 +40,7 @@ public class NotificationTest {
         content.put("sent_at", "2016-03-01T08:30:03.000Z");
         content.put("completed_at", "2016-03-01T08:30:43.000Z");
         content.put("estimated_delivery", "2016-03-03T16:00:00.000Z");
+        content.put("created_by_name", "John Doe");
         Notification notification = new Notification(content.toString());
         assertEquals(UUID.fromString(id), notification.getId());
         assertEquals(Optional.of("client_reference"), notification.getReference());
@@ -63,6 +64,7 @@ public class NotificationTest {
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
         assertEquals(Optional.of(new DateTime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
+        assertEquals(Optional.of("John Doe"), notification.getCreatedByName());
 
     }
 
@@ -95,6 +97,7 @@ public class NotificationTest {
         content.put("sent_at", "2016-03-01T08:30:03.000Z");
         content.put("completed_at", "2016-03-01T08:30:43.000Z");
         content.put("estimated_delivery", "2016-03-03T16:00:00.000Z");
+        content.put("created_by_name", "John Doe");
 
         Notification notification = new Notification(content.toString());
         assertEquals(UUID.fromString(id), notification.getId());
@@ -120,6 +123,7 @@ public class NotificationTest {
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
         assertEquals(Optional.of(new DateTime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
+        assertEquals(Optional.of("John Doe"), notification.getCreatedByName());
 
     }
 
@@ -153,6 +157,7 @@ public class NotificationTest {
         content.put("sent_at", "2016-03-01T08:30:03.000Z");
         content.put("completed_at", "2016-03-01T08:30:43.000Z");
         content.put("estimated_delivery", "2016-03-03T16:00:00.000Z");
+        content.put("created_by_name", "John Doe");
 
         Notification notification = new Notification(content.toString());
         assertEquals(UUID.fromString(id), notification.getId());
@@ -178,5 +183,6 @@ public class NotificationTest {
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:03.000Z")), notification.getSentAt());
         assertEquals(Optional.of(new DateTime("2016-03-01T08:30:43.000Z")), notification.getCompletedAt());
         assertEquals(Optional.of(new DateTime("2016-03-03T16:00:00.000Z")), notification.getEstimatedDelivery());
+        assertEquals(Optional.of("John Doe"), notification.getCreatedByName());
     }
 }


### PR DESCRIPTION
If the notification was sent manually, this will be the name of the sender. If the notification was uploaded as a CSV or was sent through the API, this will be `Optional.empty()`.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
