### PR TITLE
Send input stream for precompiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.10.0-RELEASE
 * Updated `Notification` to have an Optional createdByName. If the notification was sent manually, this will be the name of the sender. If the notification was sent through the API, this will be `Optional.empty()`.
+* New method, `sendPrecompiledLetterWithInputStream`, to send a precompiled letter using an InputStream rather than a file.
 
 ## 3.9.2-RELEASE
 * Updated testEmailNotificationWithoutPersonalisationReturnsErrorMessageIT to only look for the BadRequestError rather than the json "error": BadRequestError

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -337,7 +337,7 @@ LetterResponse response = client.sendPrecompiledLetter(
 ```
 
 ```java
-LetterResponse response = client.sendPrecompiledLetterWithInoutStream(
+LetterResponse response = client.sendPrecompiledLetterWithInputStream(
     reference,
     precompiledPDFAsInputStream);
 ```
@@ -352,7 +352,7 @@ You must create this unique identifier. This reference identifies a single uniqu
 String reference="STRING";
 ```
 
-#### precompiledPDFAsFile (required)
+#### precompiledPDFAsFile (required for the sendPrecompiledLetter method)
 
 The precompiled letter must be a PDF file. This argument adds the precompiled letter PDF file to a Java file object. The method sends this Java file object to GOV.UK Notify.
 
@@ -360,7 +360,7 @@ The precompiled letter must be a PDF file. This argument adds the precompiled le
 File precompiledPDF = new File("<PDF file path>");
 ```
 
-#### precompiledPDFAsInputStream (required)
+#### precompiledPDFAsInputStream (required for the sendPrecompiledLetterWithInputStream method)
 
 The precompiled letter must be an InputStream. This argument adds the precompiled letter PDF content to a Java InputStream object. The method sends this InputStream to GOV.UK Notify.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -333,7 +333,13 @@ This is an invitation-only feature. Contact the GOV.UK Notify team on the [suppo
 ```java
 LetterResponse response = client.sendPrecompiledLetter(
     reference,
-    precompiledPDF);
+    precompiledPDFAsFile);
+```
+
+```java
+LetterResponse response = client.sendPrecompiledLetterWithInoutStream(
+    reference,
+    precompiledPDFAsInputStream);
 ```
 
 ### Arguments
@@ -346,12 +352,20 @@ You must create this unique identifier. This reference identifies a single uniqu
 String reference="STRING";
 ```
 
-#### precompiledPDF (required)
+#### precompiledPDFAsFile (required)
 
 The precompiled letter must be a PDF file. This argument adds the precompiled letter PDF file to a Java file object. The method sends this Java file object to GOV.UK Notify.
 
 ```java
 File precompiledPDF = new File("<PDF file path>");
+```
+
+#### precompiledPDFAsInputStream (required)
+
+The precompiled letter must be an InputStream. This argument adds the precompiled letter PDF content to a Java InputStream object. The method sends this InputStream to GOV.UK Notify.
+
+```java
+InputStream precompiledPDFAsInputStream = new FileInputStream(pdfContent);
 ```
 
 ### Response

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -1,6 +1,7 @@
 package uk.gov.service.notify;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.Map;
 
 public interface NotificationClientApi {
@@ -99,6 +100,20 @@ public interface NotificationClientApi {
      * @throws NotificationClientException
      */
     LetterResponse sendPrecompiledLetter(String reference, File precompiledPDF) throws NotificationClientException;
+
+    /**
+     * The sendPrecompiledLetterWithInputStream method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
+     *
+     * @param reference                 A reference specified by the service for the notification. Get all notifications can be filtered by this reference.
+     *                                  This reference can be unique or used used to refer to a batch of notifications.
+     *                                  Cannot be an empty string or null for precompiled PDF files.
+     * @param stream                    An <code>InputStream</code> conforming to the Notify standards for printing.
+     *                                  The InputStream cannot be null.
+     * @return <code>LetterResponse</code>
+     *
+     * @throws NotificationClientException
+     */
+    public LetterResponse sendPrecompiledLetterWithInputStream(String reference, InputStream stream) throws NotificationClientException;
 
     /**
      * The getNotificationById method will return a <code>Notification</code> for a given notification id.

--- a/src/main/java/uk/gov/service/notify/PdfUtils.java
+++ b/src/main/java/uk/gov/service/notify/PdfUtils.java
@@ -1,39 +1,11 @@
 package uk.gov.service.notify;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.util.Base64;
 import java.util.Scanner;
 
 public class PdfUtils
 {
-    /**
-     * A method to determine if a file is a pdf file
-     *
-     * @param file A file object containing a PDF file to send via the API
-     *
-     * @return True if the file is a PDF, otherwise false
-     *
-     * @throws NotificationClientException If the file cannot be opened
-     */
-    public static boolean isFilePDF(File file) throws NotificationClientException
-    {
-        Scanner input;
-
-        try
-        {
-            input = new Scanner(new FileReader(file));
-        }
-        catch (FileNotFoundException e)
-        {
-            throw new NotificationClientException("Error reading PDF file", e);
-        }
-
-        return isPDF(input);
-    }
-
     /**
      * A method to determine if a file is a pdf file
      *

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -1,11 +1,10 @@
 package uk.gov.service.notify;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Optional;
@@ -264,6 +263,33 @@ public class ClientIntegrationTestIT {
         testGetReceivedTextMessagesWithOlderThanId(receivedTextMessage.getId(), client);
     }
 
+    @Test
+    public void testSendPrecompiledLetterValidPDFFileIT() throws Exception {
+        String reference = UUID.randomUUID().toString();
+
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("one_page_pdf.pdf").getFile());
+        NotificationClient client = getClient();
+        LetterResponse response =  client.sendPrecompiledLetter(reference, file);
+
+        assertPrecompiledLetterResponse(reference, response);
+
+    }
+
+    @Test
+    public void testSendPrecompiledLetterWithInputStream() throws Exception {
+        String reference = UUID.randomUUID().toString();
+
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("one_page_pdf.pdf").getFile());
+        InputStream stream = new FileInputStream(file);
+        NotificationClient client = getClient();
+        LetterResponse response =  client.sendPrecompiledLetterWithInputStream(reference, stream);
+
+        assertPrecompiledLetterResponse(reference, response);
+
+    }
+
     private ReceivedTextMessage assertReceivedTextMessageList(ReceivedTextMessageList response) {
         assertFalse(response.getReceivedTextMessages().isEmpty());
         assertNotNull(response.getCurrentPageLink());
@@ -421,19 +447,6 @@ public class ClientIntegrationTestIT {
         assertFalse(notification.getLine5().isPresent());
         assertFalse(notification.getLine6().isPresent());
         assertFalse(notification.getPostcode().isPresent());
-    }
-
-    @Test
-    public void testSendPrecompiledLetterValidPDFFileIT() throws Exception {
-        String reference = UUID.randomUUID().toString();
-
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("one_page_pdf.pdf").getFile());
-        NotificationClient client = getClient();
-        LetterResponse response =  client.sendPrecompiledLetter(reference, file);
-
-        assertPrecompiledLetterResponse(reference, response);
-
     }
 
     private void assertPrecompiledLetterResponse(String reference, LetterResponse response) {

--- a/src/test/java/uk/gov/service/notify/PdfUtilsTest.java
+++ b/src/test/java/uk/gov/service/notify/PdfUtilsTest.java
@@ -12,29 +12,6 @@ import static org.junit.Assert.*;
 public class PdfUtilsTest
 {
     @Test
-    public void testIsFilePDFValidPdf() throws Exception
-    {
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("one_page_pdf.pdf").getFile());
-        assertTrue(PdfUtils.isFilePDF(file));
-    }
-
-    @Test
-    public void testIsFilePDFNotValidPdf() throws Exception
-    {
-        ClassLoader classLoader = getClass().getClassLoader();
-        File file = new File(classLoader.getResource("not_a_pdf.txt").getFile());
-        assertFalse(PdfUtils.isFilePDF(file));
-    }
-
-    @Test(expected = NotificationClientException.class)
-    public void testIsFilePDFThrowException() throws Exception
-    {
-        File file = new File("this is a path");
-        PdfUtils.isFilePDF(file);
-    }
-
-    @Test
     public void testIsBase64StringNotValidPdf() throws Exception
     {
         ClassLoader classLoader = getClass().getClassLoader();


### PR DESCRIPTION
It was requested to have a method that took an InputStream to send the precompiled letter. This PR adds a new method in the NotificationClient to `sendPrecompiledLetterWithInputStream`.

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
