### PR TITLE
Remove smsSenderId from default example

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -39,8 +39,7 @@ SendSmsResponse response = client.sendSms(
     templateId,
     phoneNumber,
     personalisation,
-    reference,
-    smsSenderId
+    reference
 );
 ```
 


### PR DESCRIPTION
It’s optional. Most services aren’t using it (they don’t have multiple senders).

We’re getting a bunch of support tickets from people who have copied this example, put something that isn’t a UUID as the value of this argument and then are confused by the error they get.

This change will stop them getting the error at all.