### PR TITLE
Fix the build after an update to the docker-maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
+            <version>2.12.4</version>
             <configuration>
                 <useSystemClassLoader>false</useSystemClassLoader>
                 <argLine>-DforkCount=0 -Dhttp.proxyHost=${http-proxy-host} -Dhttp.proxyPort=${http-proxy-port} -Dhttps.proxyHost=${http-proxy-host} -Dhttps.proxyPort=${http-proxy-port} -Dhttp.nonProxyHosts="${non-proxy-hosts}"</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
             <executions>
                 <execution>
                     <id>attach-sources</id>
@@ -86,6 +87,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.0.1</version>
             <executions>
                 <execution>
                     <id>attach-javadocs</id>
@@ -96,10 +98,16 @@
             </executions>
         </plugin>
         <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <useSystemClassLoader>false</useSystemClassLoader>
+            </configuration>
+        </plugin>
+        <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.12.4</version>
             <configuration>
+                <useSystemClassLoader>false</useSystemClassLoader>
                 <argLine>-DforkCount=0 -Dhttp.proxyHost=${http-proxy-host} -Dhttp.proxyPort=${http-proxy-port} -Dhttps.proxyHost=${http-proxy-host} -Dhttps.proxyPort=${http-proxy-port} -Dhttp.nonProxyHosts="${non-proxy-hosts}"</argLine>
             </configuration>
             <executions>


### PR DESCRIPTION
There was an update to the docker-maven build that broke the build, https://github.com/carlossg/docker-maven/issues/90.

This will fix that. There is no need to update the version and deploy since the docker build is the only thing affected.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
