### PR TITLE
Remove "This returns the latest version of the template"

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -702,8 +702,6 @@ If the request is not successful, the client returns a `NotificationClientExcept
 
 ### Method
 
-This returns the latest version of the template.
-
 ```java
 Template template = client.getTemplateVersion(templateId, version);
 ```


### PR DESCRIPTION
## What problem does the pull request solve?

Remove "This returns the latest version of the template" from the "Get template by ID and version" template as this does not make sense.

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
