### PR TITLE
Allow lists in personalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.13.0-RELEASE
+* Allow passing of `List`s into the personalisation Map to display as a bulleted list in the message.
+
 ## 3.12.0-RELEASE
 * Added `NotificationClient.prepareUpload` method that can be used if you want to upload a document and send a link to that docuemnt by email. 
   - Takes a byte[] of document contents

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -67,9 +67,10 @@ String phoneNumber="+447900900123";
 If a template has placeholder fields for personalised information such as name or reference number, you must provide their values in a map. For example:
 
 ```java
-Map<String, String> personalisation = new HashMap<>();
+Map<String, Object> personalisation = new HashMap<>();
 personalisation.put("first_name", "Amala");
 personalisation.put("application_date", "2018-01-01");
+personalisation.put("list", listOfItems); // Will appear as a comma separated list in the message
 ```
 
 If a template does not have any placeholder fields for personalised information, you must pass in an empty map or `null`.
@@ -173,9 +174,11 @@ String emailAddress='sender@something.com';
 If a template has placeholder fields for personalised information such as name or application date, you must provide their values in a map. For example:
 
 ```java
-Map<String, String> personalisation = new HashMap<>();
+Map<String, Object> personalisation = new HashMap<>();
 personalisation.put("first_name", "Amala");
 personalisation.put("application_date", "2018-01-01");
+personalisation.put("list", listOfItems); // Will appear as a bulleted list in the message
+
 ```
 If a template does not have any placeholder fields for personalised information, you must pass in an empty map or `null`.
 
@@ -329,12 +332,13 @@ The personalisation argument always contains the following parameters for the le
 Any other placeholder fields included in the letter template also count as required parameters. You must provide their values in a map. For example:
 
 ```java
-HashMap<String, String> personalisation = new HashMap<>();
+Map<String, Object> personalisation = new HashMap<>();
 personalisation.put("address_line_1", "The Occupier"); // mandatory address field
 personalisation.put("address_line_2", "Flat 2"); // mandatory address field
 personalisation.put("postcode", "SW14 6BH"); // mandatory address field
 personalisation.put("first_name", "Amala"); // field from template
 personalisation.put("application_date", "2018-01-01"); // field from template
+personalisation.put("list", listOfItems); // Will appear as a bulleted list in the message
 ```
 
 If a template does not have any placeholder fields for personalised information, you must pass in an empty map or `null`.
@@ -810,7 +814,7 @@ String templateId='f33517ff-2a88-4f6e-b855-c550268ce08a';
 If a template has placeholder fields for personalised information such as name or application date, you must provide their values in a map. For example:
 
 ```java
-Map<String, String> personalisation = new HashMap<>();
+Map<String, Object> personalisation = new HashMap<>();
 personalisation.put("first_name", "Amala");
 personalisation.put("application_date", "2018-01-01");
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.12.0-RELEASE</version>
+    <version>3.13.0-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -168,13 +168,13 @@ public class NotificationClient implements NotificationClientApi {
         return new SendEmailResponse(response);
     }
 
-    public SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference) throws NotificationClientException {
+    public SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, ?> personalisation, String reference) throws NotificationClientException {
         return sendSms(templateId, phoneNumber, personalisation, reference, "");
     }
 
     public SendSmsResponse sendSms(String templateId,
                                    String phoneNumber,
-                                   Map<String, String> personalisation,
+                                   Map<String, ?> personalisation,
                                    String reference,
                                    String smsSenderId) throws NotificationClientException {
 
@@ -193,7 +193,7 @@ public class NotificationClient implements NotificationClientApi {
         return new SendSmsResponse(response);
     }
 
-    public SendLetterResponse sendLetter(String templateId, Map<String, String> personalisation, String reference) throws NotificationClientException {
+    public SendLetterResponse sendLetter(String templateId, Map<String, ?> personalisation, String reference) throws NotificationClientException {
         JSONObject body = createBodyForPostRequest(templateId, null, null, personalisation, reference, null);
         HttpURLConnection conn = createConnectionAndSetHeaders(baseUrl + "/v2/notifications/letter", "POST");
         String response = performPostRequest(conn, body, HttpsURLConnection.HTTP_CREATED);

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -262,7 +262,7 @@ public class NotificationClient implements NotificationClientApi {
         }
     }
 
-    public TemplatePreview generateTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException {
+    public TemplatePreview generateTemplatePreview(String templateId, Map<String, Object> personalisation) throws NotificationClientException {
         JSONObject body = new JSONObject();
         if (personalisation != null && !personalisation.isEmpty()) {
             body.put("personalisation", new JSONObject(personalisation));

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -54,7 +54,7 @@ public interface NotificationClientApi {
      * @return <code>SendSmsResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#error-codes
      */
-    SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference) throws NotificationClientException;
+    SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, ?> personalisation, String reference) throws NotificationClientException;
 
     /**
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
@@ -72,7 +72,7 @@ public interface NotificationClientApi {
      * @return <code>SendSmsResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#error-codes
      */
-    SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, String> personalisation, String reference, String smsSenderId) throws NotificationClientException;
+    SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, ?> personalisation, String reference, String smsSenderId) throws NotificationClientException;
 
     /**
      * The sendLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
@@ -86,7 +86,7 @@ public interface NotificationClientApi {
      * @return <code>SendLetterResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#send-a-letter-error-codes
      */
-    SendLetterResponse sendLetter(String templateId, Map<String, String> personalisation, String reference) throws NotificationClientException;
+    SendLetterResponse sendLetter(String templateId, Map<String, ?> personalisation, String reference) throws NotificationClientException;
 
     /**
      * The sendPrecompiledLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -178,7 +178,7 @@ public interface NotificationClientApi {
      * @return <code>Template</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#generate-a-preview-template-error-codes
      */
-    TemplatePreview generateTemplatePreview(String templateId, Map<String, String> personalisation) throws NotificationClientException;
+    TemplatePreview generateTemplatePreview(String templateId, Map<String, Object> personalisation) throws NotificationClientException;
 
     /**
      * The getReceivedTextMessages returns a list of <code>ReceivedTextMessage</code>, the list is sorted by createdAt descending.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.12.0-RELEASE
+project.version=3.13.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -264,7 +264,7 @@ public class ClientIntegrationTestIT {
     @Test
     public void testGetTemplatePreview() throws NotificationClientException {
         NotificationClient client = getClient();
-        HashMap<String, String> personalisation = new HashMap<>();
+        HashMap<String, Object> personalisation = new HashMap<>();
         String uniqueName = UUID.randomUUID().toString();
         personalisation.put("name", uniqueName);
         TemplatePreview template = client.generateTemplatePreview(System.getenv("EMAIL_TEMPLATE_ID"), personalisation);

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -9,7 +9,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.UUID;
@@ -357,7 +356,6 @@ public class ClientIntegrationTestIT {
         HashMap<String, Object> personalisation = new HashMap<>();
         String uniqueName = UUID.randomUUID().toString();
         personalisation.put("name", uniqueName);
-        personalisation.put("list", Collections.singletonList("value"));
         SendSmsResponse response = client.sendSms(System.getenv("SMS_TEMPLATE_ID"), System.getenv("FUNCTIONAL_TEST_NUMBER"), personalisation, uniqueName);
         assertNotificationSmsResponse(response, uniqueName);
         return response;

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -9,6 +9,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.UUID;
@@ -353,9 +354,10 @@ public class ClientIntegrationTestIT {
     }
 
     private SendSmsResponse sendSmsAndAssertResponse(final NotificationClient client) throws NotificationClientException {
-        HashMap<String, String> personalisation = new HashMap<>();
+        HashMap<String, Object> personalisation = new HashMap<>();
         String uniqueName = UUID.randomUUID().toString();
         personalisation.put("name", uniqueName);
+        personalisation.put("list", Collections.singletonList("value"));
         SendSmsResponse response = client.sendSms(System.getenv("SMS_TEMPLATE_ID"), System.getenv("FUNCTIONAL_TEST_NUMBER"), personalisation, uniqueName);
         assertNotificationSmsResponse(response, uniqueName);
         return response;

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -48,7 +48,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.12.0-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.13.0-RELEASE");
     }
 
     @Test


### PR DESCRIPTION
## What problem does the pull request solve?
There is an undocumented feature to pass lists of items in the personalisation but the API prevents this as it requires a `Map<String, String>` for the `personalisation` parameter.
The `sendEmail` method does already allow `Map<String, ?>` so my change is simply to allow the same for letters and SMSs.

## Checklist

- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
