### PR TITLE
Accessibility header change

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -850,6 +850,14 @@ This API call returns one page of up to 250 received text messages. You can get 
 
 You can only get messages that are 7 days old or newer.
 
+## Enable received text messages
+
+Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) to enable receiving text messages for your service.
+
+For more information, refer to the [callbacks documentation](/java.html#callbacks).
+
+## Set up received text messages
+
 ### Method
 
 ```java

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -850,13 +850,13 @@ This API call returns one page of up to 250 received text messages. You can get 
 
 You can only get messages that are 7 days old or newer.
 
+You can also set up [callbacks](/java.html#callbacks) for received text messages.
+
 ## Enable received text messages
 
 Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) to enable receiving text messages for your service.
 
-For more information, refer to the [callbacks documentation](/java.html#callbacks).
-
-## Set up received text messages
+## Get a page of received text messages
 
 ### Method
 


### PR DESCRIPTION
## What problem does the pull request solve?

Accessibility requirements state that you cannot miss out heading levels e.g. you cannot go from an H1 to an H3 or from H2 to H4.

This change adds content into the `Get received text messages` section so it complies with this requirement.

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
