### PR TITLE
Adding html field to response from the template preview

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -835,6 +835,7 @@ String templateType;
 int version;
 String body;
 Optional<String> subject;
+Optional<String> html;
 ```
 
 ### Error codes

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.13.0-RELEASE</version>
+    <version>3.14.0-RELEASE</version>
     <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/uk/gov/service/notify/TemplatePreview.java
+++ b/src/main/java/uk/gov/service/notify/TemplatePreview.java
@@ -11,6 +11,7 @@ public class TemplatePreview {
         private int version;
         private String body;
         private String subject;
+        private String html;
 
 
         public TemplatePreview(String content){
@@ -30,6 +31,7 @@ public class TemplatePreview {
             version = data.getInt("version");
             body = data.getString("body");
             subject = data.isNull("subject") ? null : data.getString("subject");
+            html = data.isNull("html") ? null : data.getString("html");
         }
 
         public UUID getId() {
@@ -72,6 +74,14 @@ public class TemplatePreview {
             this.subject = subject;
         }
 
+        public Optional<String> getHtml() {
+            return Optional.ofNullable(html);
+        }
+        public void setHtml(String html) {
+            this.html = html;
+        }
+
+
         @Override
         public String toString() {
             return "Template{" +
@@ -80,6 +90,7 @@ public class TemplatePreview {
                     ", version=" + version +
                     ", body='" + body + '\'' +
                     ", subject='" + subject + '\'' +
+                    ", html='" + html + '\'' +
                     '}';
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.13.0-RELEASE
+project.version=3.14.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -48,7 +48,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.13.0-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.14.0-RELEASE");
     }
 
     @Test

--- a/src/test/java/uk/gov/service/notify/TemplatePreviewTest.java
+++ b/src/test/java/uk/gov/service/notify/TemplatePreviewTest.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TemplatePreviewTest {
 
@@ -26,5 +27,25 @@ public class TemplatePreviewTest {
         assertEquals(3, template.getVersion());
         assertEquals("The body of the template. For ((name)) eyes only.", template.getBody());
         assertEquals(Optional.of("Private email"), template.getSubject());
+        assertEquals(Optional.empty(), template.getHtml());
+    }
+
+    public void testTemplatePreview_canCreateObjectFromJsonWithHtml() {
+        JSONObject content = new JSONObject();
+        String id = UUID.randomUUID().toString();
+        content.put("id", id);
+        content.put("type", "email");
+        content.put("version", 3);
+        content.put("body", "The body of the template. For ((name)) eyes only.");
+        content.put("subject", "Private email");
+        content.put("html", "html version of the body");
+
+        TemplatePreview template = new TemplatePreview(content.toString());
+        assertEquals(UUID.fromString(id), template.getId());
+        assertEquals("email", template.getTemplateType());
+        assertEquals(3, template.getVersion());
+        assertEquals("The body of the template. For ((name)) eyes only.", template.getBody());
+        assertEquals(Optional.of("Private email"), template.getSubject());
+        assertEquals(Optional.of("html version of the body"), template.getHtml());
     }
 }


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Adds the html field to the TemplatePreview object

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
