### PR TITLE
Add statement on using API directly

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,6 +2,8 @@
 
 This documentation is for developers interested in using the GOV.UK Notify Java client to send emails, text messages or letters.
 
+We recommend that you use this client library rather than use the [GOV.UK Notify API](https://github.com/alphagov/notifications-api) directly, as there is no documentation for using the API in this way.
+
 # Set up the client
 
 ## Install the client


### PR DESCRIPTION
## What problem does the pull request solve?

There have been multiple support tickets asking how to use the API directly instead of the API client. This PR adds a statement recommending that users use the API client instead of the API due to lack of documentation.

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
