### PR TITLE
Update reply-to email addresses section and negative contraction

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -203,15 +203,15 @@ A unique identifier you create. This reference identifies a single unique notifi
 String reference='STRING';
 ```
 
-#### emailReplyToId (optional)
+#### email_reply_to_id (optional)
 
-This is an email address specified by you to receive replies from your users. You must add at least one email reply-to address before your service can go live.
+This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
 
-To add a reply-to address:
+To add a reply-to email address:
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Settings__ page.
-1. In the Email section, select __Manage__ on the __Email reply-to addresses__ row.
+1. In the __Email__ section, select __Manage__ on the __Reply-to email addresses__ row.
 1. Select __Add reply-to address__.
 1. Enter the email address you want to use, and select __Add__.
 
@@ -854,7 +854,7 @@ TemplateList templates = client.getAllTemplates(templateType);
 
 #### templateType (optional)
 
-If you don’t use `templateType`, the client returns all templates. Otherwise you can filter by:
+If you do not use `templateType`, the client returns all templates. Otherwise you can filter by:
 
 - `email`
 - `sms`


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Corrects inconsistencies in the language and formatting of the reply-to email address section.
Removes one use of a negative contraction

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number (in `src/main/resources/application.properties`)
      and run the `update_version.sh` script
