### PR TITLE
Consistent context for email_reply_to_id and smsSenderId across our client documentation (Java)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -109,7 +109,7 @@ String smsSenderId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 ```
 
 
-If you do not have an `smsSenderId`, you can leave out this argument.
+You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.
 
 ### Response
 
@@ -219,7 +219,7 @@ To add a reply-to email address:
 String emailReplyToId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 ```
 
-If you do not have an `emailReplyToId`, you can leave out this argument.
+You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.
 
 ### Response
 


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->
When mentioning the optional argument `email_reply_to_id` It should say across all clients:

> You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.

Similarly, for `smsSenderId`, all clients should use:

> You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.

Pivotal story: https://www.pivotaltracker.com/story/show/170575582

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number
    - [ ] in `src/main/resources/application.properties`
    - [ ] in `src/test/java/uk/gov/service/notify/NotificationClientTest.java::testCreateNotificationClientSetsUserAgent`
    - [ ] and run the `update_version.sh` script
