### PR TITLE
Update tests and documentation to work with postcode validation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -356,7 +356,7 @@ The personalisation argument always contains the following parameters for the le
 
 - `address_line_1`
 - `address_line_2`
-- `postcode`
+- `postcode` (this needs to be a real UK postcode)
 
 Any other placeholder fields included in the letter template also count as required parameters. You must provide their values in a map. For example:
 
@@ -364,7 +364,7 @@ Any other placeholder fields included in the letter template also count as requi
 Map<String, Object> personalisation = new HashMap<>();
 personalisation.put("address_line_1", "The Occupier"); // mandatory address field
 personalisation.put("address_line_2", "Flat 2"); // mandatory address field
-personalisation.put("postcode", "SW14 6BH"); // mandatory address field
+personalisation.put("postcode", "SW14 6BH"); // mandatory address field, must be a real UK postcode
 personalisation.put("first_name", "Amala"); // field from template
 personalisation.put("application_date", "2018-01-01"); // field from template
 personalisation.put("list", listOfItems); // Will appear as a bulleted list in the message
@@ -414,6 +414,7 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation address_line_1 is a required property"`<br>`}]`|Ensure that your template has a field for the first line of the address, refer to [personalisation](#send-a-letter-arguments-personalisation-required) for more information|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Must be a real UK postcode"`<br>`}]`|Ensure that the value for the postcode field in your letter is a real UK postcode|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|Refer to [API rate limits](#rate-limits) for more information|

--- a/src/test/java/uk/gov/service/notify/NotificationListTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationListTest.java
@@ -75,7 +75,7 @@ public class NotificationListTest {
         letter.put("line_4", null);
         letter.put("line_5", null);
         letter.put("line_6", null);
-        letter.put("postcode", "sw1 1aa");
+        letter.put("postcode", "SW1 1AA");
         letter.put("postage", "first");
         letter.put("type", "email");
         letter.put("status", "delivered");

--- a/src/test/java/uk/gov/service/notify/NotificationTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationTest.java
@@ -146,7 +146,7 @@ public class NotificationTest {
         content.put("line_4", null);
         content.put("line_5", null);
         content.put("line_6", null);
-        content.put("postcode", "sw1 1aa");
+        content.put("postcode", "SW1 1AA");
         content.put("postage", "first");
         content.put("type", "letter");
         content.put("status", "delivered");
@@ -178,7 +178,7 @@ public class NotificationTest {
         assertEquals(Optional.<String>empty(), notification.getLine4());
         assertEquals(Optional.<String>empty(), notification.getLine5());
         assertEquals(Optional.<String>empty(), notification.getLine6());
-        assertEquals(Optional.of("sw1 1aa"), notification.getPostcode());
+        assertEquals(Optional.of("SW1 1AA"), notification.getPostcode());
         assertEquals(Optional.of("first"), notification.getPostage());
         assertEquals(UUID.fromString(templateId), notification.getTemplateId());
         assertEquals(1, notification.getTemplateVersion());


### PR DESCRIPTION
This work is for this PR to work properly when deploying (otherwise client integrations tests will start failing): https://github.com/alphagov/notifications-api/pull/2751

for tests, use properly formatted postcode so there are no disparities when asserting, as our app will format the postcode now.