### PR TITLE
Add documentation about using a proxy with the java client.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -26,6 +26,13 @@ NotificationClient client = new NotificationClient(apiKey);
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
 
+If you use a proxy you can pass it into the NotificationClient constructor.
+
+```java
+import uk.gov.service.notify.NotificationClient;
+NotificationClient client = new NotificationClient(apiKey, proxy);
+```
+
 # Send a message
 
 You can use GOV.UK Notify to send text messages, emails and letters.


### PR DESCRIPTION
## What problem does the pull request solve?
It's common to use a proxy to send HTTPS requests, it's always been possible however we never mentioned it in the documentation. Now we do.
