### PR TITLE
Rename whitelist to guest list

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -134,7 +134,7 @@ Optional<String> fromNumber;
 
 If you are using the [test API key](#test), all your messages come back with a `delivered` status.
 
-All messages sent using the [team and whitelist](#team-and-whitelist) or [live](#live) keys appear on your dashboard.
+All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys appear on your dashboard.
 
 ### Error codes
 


### PR DESCRIPTION
We’re renaming the ‘Team and whitelist’ key in https://github.com/alphagov/notifications-admin/pull/3479

This commit updates the documentation to match.
