### PR TITLE
Null pointer exception on reading the errorstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.4.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
             <version>0.6.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.15.2-RELEASE</version>
+    <version>3.15.3-RELEASE</version>
     <properties>
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -321,11 +321,9 @@ public class NotificationClient implements NotificationClientApi {
 
             int httpResult = conn.getResponseCode();
             if (httpResult == expectedStatusCode) {
-                StringBuilder sb = readStream(new InputStreamReader(conn.getInputStream(), UTF_8));
-                return sb.toString();
+                return readStream(conn.getInputStream());
             } else {
-                StringBuilder sb = readStream(new InputStreamReader(conn.getErrorStream(), UTF_8));
-                throw new NotificationClientException(httpResult, sb.toString());
+                throw new NotificationClientException(httpResult, readStream(conn.getErrorStream()));
             }
 
         } catch (IOException e) {
@@ -343,12 +341,9 @@ public class NotificationClient implements NotificationClientApi {
             int httpResult = conn.getResponseCode();
             StringBuilder stringBuilder;
             if (httpResult == 200) {
-                stringBuilder = readStream(new InputStreamReader(conn.getInputStream(), UTF_8));
-                conn.disconnect();
-                return stringBuilder.toString();
+                return readStream(conn.getInputStream());
             } else {
-                stringBuilder = readStream(new InputStreamReader(conn.getErrorStream(), UTF_8));
-                throw new NotificationClientException(httpResult, stringBuilder.toString());
+                throw new NotificationClientException(httpResult, readStream(conn.getErrorStream()));
             }
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, e.toString(), e);
@@ -368,9 +363,7 @@ public class NotificationClient implements NotificationClientApi {
                 InputStream is = conn.getInputStream();
                 out = IOUtils.toByteArray(is);
             } else {
-                // errors should be read as a string
-                String s = readStream(new InputStreamReader(conn.getErrorStream(), UTF_8)).toString();
-                throw new NotificationClientException(httpResult, s);
+                throw new NotificationClientException(httpResult, readStream(conn.getErrorStream()));
             }
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, e.toString(), e);
@@ -455,7 +448,11 @@ public class NotificationClient implements NotificationClientApi {
         return body;
     }
 
-    private StringBuilder readStream(InputStreamReader streamReader) throws IOException {
+    private String readStream(InputStream inputStream) throws IOException {
+        if (inputStream == null) {
+            return null;
+        }
+        InputStreamReader streamReader = new InputStreamReader(inputStream, UTF_8);
         StringBuilder sb = new StringBuilder();
         BufferedReader br = new BufferedReader(streamReader);
         String line;
@@ -463,7 +460,7 @@ public class NotificationClient implements NotificationClientApi {
             sb.append(line).append("\n");
         }
         br.close();
-        return sb;
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -452,15 +452,7 @@ public class NotificationClient implements NotificationClientApi {
         if (inputStream == null) {
             return null;
         }
-        InputStreamReader streamReader = new InputStreamReader(inputStream, UTF_8);
-        StringBuilder sb = new StringBuilder();
-        BufferedReader br = new BufferedReader(streamReader);
-        String line;
-        while ((line = br.readLine()) != null) {
-            sb.append(line).append("\n");
-        }
-        br.close();
-        return sb.toString();
+        return IOUtils.toString(inputStream, UTF_8);
     }
 
     /**

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -399,7 +399,7 @@ public class NotificationClient implements NotificationClientApi {
         }
     }
 
-    private HttpURLConnection getConnection(URL url) throws IOException {
+    HttpURLConnection getConnection(URL url) throws IOException {
         HttpURLConnection conn;
 
         if (null != proxy) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.15.2-RELEASE
+project.version=3.15.3-RELEASE

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -48,7 +48,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.15.2-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.15.3-RELEASE");
     }
 
     @Test

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -5,15 +5,19 @@ import org.json.JSONObject;
 import org.junit.Test;
 
 import javax.net.ssl.SSLContext;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
 
 public class NotificationClientTest {
 
@@ -107,5 +111,20 @@ public class NotificationClientTest {
             assertEquals(e.getHttpResult(), 413);
             assertEquals(e.getMessage(), "Status code: 413 File is larger than 2MB");
         }
+    }
+
+    @Test(expected = NotificationClientException.class)
+    public void testShouldThrowNotificationExceptionOnErrorResponseCodeAndNoErrorStream() throws Exception {
+        NotificationClient client = spy(new NotificationClient(combinedApiKey, baseUrl));
+        doReturn(mockConnection(404)).when(client).getConnection(any());
+
+        client.sendSms("aTemplateId", "aPhoneNumber", emptyMap(), "aReference");
+    }
+
+    private HttpURLConnection mockConnection(int statusCode) throws Exception {
+        HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+        when(mockConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+        when(mockConnection.getResponseCode()).thenReturn(statusCode);
+        return mockConnection;
     }
 }


### PR DESCRIPTION
## What problem does the pull request solve?
Addresses issue #171 _Null pointer exception on reading the errorstream_.
An intermittent NullPointerException is thrown from the client when an error status code is returned from Notify. This is caused by not checking for the existence of an error stream before using it.  This PR ensures the stream is only read if its available.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes - tests pass (no changes)
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)  - no changes required
- [x] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `src/test/java/uk/gov/service/notify/NotificationClientTest.java::testCreateNotificationClientSetsUserAgent`
    - [x] and run the `update_version.sh` script
