### PR TITLE
Add optional `isCsv` parameter to ensure CSVs download as .csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.16.0-RELEASE
+* Add support for an optional `isCsv` parameter in the `prepareUpload()` function. This fixes a bug when sending a CSV file by email. This ensures that the file is downloaded as a CSV rather than a TXT file.
+
+## 3.15.3-RELEASE
+* Fixes issue #171 with null pointer exception on reading the errorstream
+
 ## 3.15.2-RELEASE
 * Change error messages to refer to file, not document.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -303,6 +303,24 @@ client.sendEmail(templateId,
                  emailReplyToId);
 ```
 
+#### CSV Files
+
+Uploads for CSV files should use the `isCsv` parameter on the `prepareUpload()` function.  For example:
+
+```java
+ClassLoader classLoader = getClass().getClassLoader();
+File file = new File(classLoader.getResource("document_to_upload.pdf").getFile());
+byte [] fileContents = FileUtils.readFileToByteArray(file);
+
+HashMap<String, Object> personalisation = new HashMap();
+personalisation.put("link_to_file", client.prepareUpload(fileContents, true));
+client.sendEmail(templateId,
+                 emailAddress,
+                 personalisation,
+                 reference,
+                 emailReplyToId);
+```
+
 ### Error codes
 
 If the request is not successful, the client returns an `HTTPError` containing the relevant error code.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.15.3-RELEASE</version>
+    <version>3.16.0-RELEASE</version>
     <properties>
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -299,9 +299,10 @@ public class NotificationClient implements NotificationClientApi {
      * The prepareUpload method creates a <code>JSONObject</code> which will need to be added to the personalisation map.
      *
      * @param documentContents byte[] of the document
+     * @param isCsv boolean True if a CSV file, False if not to ensure document is downloaded as correct file type
      * @return <code>JSONObject</code> a json object to be added to the personalisation is returned
      */
-    public static JSONObject prepareUpload(final byte[] documentContents) throws NotificationClientException {
+    public static JSONObject prepareUpload(final byte[] documentContents, boolean isCsv) throws NotificationClientException {
         if (documentContents.length > 2*1024*1024){
             throw new NotificationClientException(413, "File is larger than 2MB");
         }
@@ -310,7 +311,19 @@ public class NotificationClient implements NotificationClientApi {
 
         JSONObject jsonFileObject = new JSONObject();
         jsonFileObject.put("file", fileContent);
+        jsonFileObject.put("is_csv", isCsv);
         return jsonFileObject;
+    }
+
+    /**
+     * Use the prepareUpload method when uploading a document via sendEmail.
+     * The prepareUpload method creates a <code>JSONObject</code> which will need to be added to the personalisation map.
+     *
+     * @param documentContents byte[] of the document
+     * @return <code>JSONObject</code> a json object to be added to the personalisation is returned
+     */
+    public static JSONObject prepareUpload(final byte[] documentContents) throws NotificationClientException {
+        return prepareUpload(documentContents, false);
     }
 
     private String performPostRequest(HttpURLConnection conn, JSONObject body, int expectedStatusCode) throws NotificationClientException {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.15.3-RELEASE
+project.version=3.16.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -52,7 +52,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.15.3-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.16.0-RELEASE");
     }
 
     @Test
@@ -97,7 +97,20 @@ public class NotificationClientTest {
         JSONObject response = NotificationClient.prepareUpload(documentContent);
         JSONObject expectedResult = new JSONObject();
         expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
+        expectedResult.put("is_csv", false);
         assertEquals(expectedResult.getString("file"), response.getString("file"));
+        assertEquals(expectedResult.getBoolean("is_csv"), response.getBoolean("is_csv"));
+    }
+
+    @Test
+    public void testPrepareUploadForCSV() throws NotificationClientException {
+        byte[] documentContent = "this is a document to test with".getBytes();
+        JSONObject response = NotificationClient.prepareUpload(documentContent, true);
+        JSONObject expectedResult = new JSONObject();
+        expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
+        expectedResult.put("is_csv", true);
+        assertEquals(expectedResult.getString("file"), response.getString("file"));
+        assertEquals(expectedResult.getBoolean("is_csv"), response.getBoolean("is_csv"));
     }
 
     @Test


### PR DESCRIPTION
This is equivalent to
alphagov/notifications-python-client#165 and
ensures that CSV files send using document download are downloaded as
.csv rather than .txt

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `src/test/java/uk/gov/service/notify/NotificationClientTest.java::testCreateNotificationClientSetsUserAgent`
    - [ ] and run the `update_version.sh` script
