### PR TITLE
Add letterContactBlock to template object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.17.0-RELEASE
+* Add `letterContactBlock` to the `Template` model.
+- We've added `letter_contact_block` to our API responses when calling`getTemplateById`, `getTemplateVersion` and `getAllTemplates`. This release updates our `Template` model to include this new property.
+
 ## 3.16.0-RELEASE
 * Add support for an optional `isCsv` parameter in the `prepareUpload()` function. This fixes a bug when sending a CSV file by email. This ensures that the file is downloaded as a CSV rather than a TXT file.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -801,6 +801,7 @@ int version;
 String body;
 Optional<String> subject;
 Optional<Map<String, Object>> personalisation;
+Optional<String> letterContactBlock;
 ```
 
 ### Error codes
@@ -851,6 +852,7 @@ int version;
 String body;
 Optional<String> subject;
 Optional<Map<String, Object>> personalisation;
+Optional<String> letterContactBlock;
 ```
 
 ### Error codes

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.16.0-RELEASE</version>
+    <version>3.17.0-RELEASE</version>
     <properties>
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/main/java/uk/gov/service/notify/Template.java
+++ b/src/main/java/uk/gov/service/notify/Template.java
@@ -18,6 +18,7 @@ public class Template {
     private String body;
     private String subject;
     private Map<String, Object> personalisation;
+    private String letterContactBlock;
 
 
     public Template(String content){
@@ -40,6 +41,7 @@ public class Template {
         version = data.getInt("version");
         body = data.getString("body");
         subject = data.isNull("subject") ? null : data.getString("subject");
+        letterContactBlock = data.isNull("letter_contact_block") ? null : data.getString("letter_contact_block");
         personalisation = data.isNull("personalisation") ? null :
                 JsonUtils.jsonToMap(data.getJSONObject("personalisation"));
     }
@@ -116,6 +118,14 @@ public class Template {
         this.subject = subject;
     }
 
+    public Optional<String> getLetterContactBlock() {
+        return Optional.ofNullable(letterContactBlock);
+    }
+
+    public void setLetterContactBlock(String letterContactBlock) {
+        this.letterContactBlock = letterContactBlock;
+    }
+
     public Optional<Map<String, Object>> getPersonalisation() {
         return Optional.ofNullable(personalisation);
     }
@@ -135,6 +145,7 @@ public class Template {
                 ", version=" + version +
                 ", body='" + body + '\'' +
                 ", subject='" + subject + '\'' +
+                ", letterContactBlock='" + letterContactBlock + '\'' +
                 ", personalisation='" + personalisation + '\'' +
                 '}';
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.16.0-RELEASE
+project.version=3.17.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -234,13 +234,15 @@ public class ClientIntegrationTestIT {
     @Test
     public void testGetTemplateById() throws NotificationClientException {
         NotificationClient client = getClient();
-        Template template = client.getTemplateById(System.getenv("EMAIL_TEMPLATE_ID"));
-        assertEquals(System.getenv("EMAIL_TEMPLATE_ID"), template.getId().toString());
+        Template template = client.getTemplateById(System.getenv("LETTER_TEMPLATE_ID"));
+        assertEquals(System.getenv("LETTER_TEMPLATE_ID"), template.getId().toString());
         assertNotNull(template.getCreatedAt());
         assertNotNull(template.getTemplateType());
         assertNotNull(template.getBody());
-        assertNotNull(template.getSubject());
         assertNotNull(template.getName());
+        assertNotNull(template.getVersion());
+        assertNotNull(template.getSubject());
+        assertNotNull(template.getLetterContactBlock());
     }
 
     @Test
@@ -252,6 +254,7 @@ public class ClientIntegrationTestIT {
         assertNotNull(template.getTemplateType());
         assertNotNull(template.getBody());
         assertNotNull(template.getName());
+        assertNotNull(template.getVersion());
     }
 
     @Test

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -52,7 +52,7 @@ public class NotificationClientTest {
     @Test
     public void testCreateNotificationClientSetsUserAgent() {
         NotificationClient client = new NotificationClient(combinedApiKey, baseUrl);
-        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.16.0-RELEASE");
+        assertEquals(client.getUserAgent(), "NOTIFY-API-JAVA-CLIENT/3.17.0-RELEASE");
     }
 
     @Test


### PR DESCRIPTION
We've added `letter_contact_block` to our API responses when calling
`getTemplateById`, `getTemplateVersion` and `getAllTemplates`. This
commit updates our `Template` model to include this new property and
documents it.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `src/test/java/uk/gov/service/notify/NotificationClientTest.java::testCreateNotificationClientSetsUserAgent`
    - [ ] and run the `update_version.sh` script
