### PR TITLE
Adjust heading levels in DOCUMENTATION.md

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,9 +2,9 @@
 
 This documentation is for developers interested in using the GOV.UK Notify Java client to send emails, text messages or letters.
 
-# Set up the client
+## Set up the client
 
-## Install the client
+### Install the client
 
 The `notifications-java-client` deploys to Bintray.
 
@@ -15,7 +15,7 @@ Go to the [GOV.UK Notify Java client page on Bintray](https://bintray.com/gov-uk
 
 Refer to the [client changelog](https://github.com/alphagov/notifications-java-client/blob/master/CHANGELOG.md) for the version number and the latest updates.
 
-## Create a new instance of the client
+### Create a new instance of the client
 
 Add this code to your application:
 
@@ -33,13 +33,13 @@ import uk.gov.service.notify.NotificationClient;
 NotificationClient client = new NotificationClient(apiKey, proxy);
 ```
 
-# Send a message
+## Send a message
 
 You can use GOV.UK Notify to send text messages, emails and letters.
 
-## Send a text message
+### Send a text message
 
-### Method
+#### Method
 
 ```java
 SendSmsResponse response = client.sendSms(
@@ -51,9 +51,9 @@ SendSmsResponse response = client.sendSms(
 );
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -67,7 +67,7 @@ For example:
 String templateId="f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-#### phoneNumber (required)
+##### phoneNumber (required)
 
 The phone number of the recipient of the text message. This number can be a UK or international number.
 
@@ -75,7 +75,7 @@ The phone number of the recipient of the text message. This number can be a UK o
 String phoneNumber="+447900900123";
 ```
 
-#### personalisation (required)
+##### personalisation (required)
 
 If a template has placeholder fields for personalised information such as name or reference number, you must provide their values in a map. For example:
 
@@ -88,7 +88,7 @@ personalisation.put("list", listOfItems); // Will appear as a comma separated li
 
 If a template does not have any placeholder fields for personalised information, you must pass in an empty map or `null`.
 
-#### reference (required)
+##### reference (required)
 
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. If you do not have a reference, you must pass in an empty string or `null`.
 
@@ -96,7 +96,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 String reference='STRING';
 ```
 
-#### smsSenderId (optional)
+##### smsSenderId (optional)
 
 A unique identifier of the sender of the text message notification.
 
@@ -118,7 +118,7 @@ String smsSenderId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 
 You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `SendSmsResponse`:
 
@@ -136,7 +136,7 @@ If you are using the [test API key](#test), all your messages come back with a `
 
 All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys appear on your dashboard.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -150,9 +150,9 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification|
 
-## Send an email
+### Send an email
 
-### Method
+#### Method
 
 ```java
 SendEmailResponse response = client.sendEmail(
@@ -164,10 +164,10 @@ SendEmailResponse response = client.sendEmail(
 );
 ```
 
-### Arguments
+#### Arguments
 
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -181,7 +181,7 @@ For example:
 String templateId="f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-#### emailAddress (required)
+##### emailAddress (required)
 
 The email address of the recipient.
 
@@ -189,7 +189,7 @@ The email address of the recipient.
 String emailAddress='sender@something.com';
 ```
 
-#### personalisation (required)
+##### personalisation (required)
 
 If a template has placeholder fields for personalised information such as name or application date, you must provide their values in a map. For example:
 
@@ -202,7 +202,7 @@ personalisation.put("list", listOfItems); // Will appear as a bulleted list in t
 ```
 If a template does not have any placeholder fields for personalised information, you must pass in an empty map or `null`.
 
-#### reference (required)
+##### reference (required)
 
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. If you do not have a reference, you must pass in an empty string or `null`.
 
@@ -210,7 +210,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 String reference='STRING';
 ```
 
-#### emailReplyToId (optional)
+##### emailReplyToId (optional)
 
 This is an email address specified by you to receive replies from your users. You must add at least one reply-to email address before your service can go live.
 
@@ -228,7 +228,7 @@ String emailReplyToId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 
 You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `SendEmailResponse`:
 
@@ -243,7 +243,7 @@ String subject;
 Optional<String> fromEmail;
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -257,20 +257,20 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification|
 
-## Send a file by email
+### Send a file by email
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
 
-### Add contact details to the file download page
+#### Add contact details to the file download page
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Settings__ page.
 1. In the __Email__ section, select __Manage__ on the __Send files by email__ row.
 1. Enter the contact details you want to use, and select __Save__.
 
-### Add a placeholder to the template
+#### Add a placeholder to the template
 
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
@@ -279,7 +279,7 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 
 "Download your file at: ((link_to_file))"
 
-### Upload your file
+#### Upload your file
 
 You can upload PDF, CSV, .odt, .txt and MS Word Document files. Your file must be smaller than 2MB. [Contact the GOV.UK Notify team](https://www.notifications.service.gov.uk/support/ask-question-give-feedback) if you need to send other file types.
 
@@ -303,7 +303,7 @@ client.sendEmail(templateId,
                  emailReplyToId);
 ```
 
-#### CSV Files
+##### CSV Files
 
 Uploads for CSV files should use the `isCsv` parameter on the `prepareUpload()` function.  For example:
 
@@ -321,7 +321,7 @@ client.sendEmail(templateId,
                  emailReplyToId);
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns an `HTTPError` containing the relevant error code.
 
@@ -339,7 +339,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
-## Send a letter
+### Send a letter
 
 When you add a new service it will start in [trial mode](https://www.notifications.service.gov.uk/features/trial-mode). You can only send letters when your service is live.
 
@@ -349,7 +349,7 @@ To send Notify a request to go live:
 1. Go to the __Settings__ page.
 1. In the __Your service is in trial mode__ section, select __request to go live__.
 
-### Method
+#### Method
 
 ```java
 SendLetterResponse response = client.sendLetter(
@@ -359,9 +359,9 @@ SendLetterResponse response = client.sendLetter(
 );
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 To find the template ID:
 
@@ -375,7 +375,7 @@ For example:
 String templateId = "f33517ff-2a88-4f6e-b855-c550268ce08a";
 ```
 
-#### personalisation (required)
+##### personalisation (required)
 
 The personalisation argument always contains the following parameters for the letter recipient’s address:
 
@@ -409,7 +409,7 @@ personalisation.put("list", listOfItems); // Will appear as a bulleted list in t
 
 If a template does not have any placeholder fields for personalised information, you must pass in an empty map or `null`.
 
-#### reference (required)
+##### reference (required)
 
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. If you do not have a reference, you must pass in an empty string or `null`.
 
@@ -417,7 +417,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 String reference='STRING';
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `SendLetterResponse`:
 
@@ -431,7 +431,7 @@ String body;
 String subject;
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -449,9 +449,9 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
 
-## Send a precompiled letter
+### Send a precompiled letter
 
-### Method
+#### Method
 
 ```java
 LetterResponse response = client.sendPrecompiledLetter(
@@ -482,9 +482,9 @@ LetterResponse response = client.sendPrecompiledLetterWithInputStream(
     );
 ```
 
-### Arguments
+#### Arguments
 
-#### reference (required)
+##### reference (required)
 
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
@@ -492,7 +492,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 String reference="STRING";
 ```
 
-#### precompiledPDFAsFile (required for the sendPrecompiledLetter method)
+##### precompiledPDFAsFile (required for the sendPrecompiledLetter method)
 
 The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf).
 
@@ -502,7 +502,7 @@ This argument adds the precompiled letter PDF file to a Java file object. The me
 File precompiledPDF = new File("<PDF file path>");
 ```
 
-#### precompiledPDFAsInputStream (required for the sendPrecompiledLetterWithInputStream method)
+##### precompiledPDFAsInputStream (required for the sendPrecompiledLetterWithInputStream method)
 
 The precompiled letter must be an InputStream. This argument adds the precompiled letter PDF content to a Java InputStream object. The method sends this InputStream to GOV.UK Notify.
 
@@ -510,11 +510,11 @@ The precompiled letter must be an InputStream. This argument adds the precompile
 InputStream precompiledPDFAsInputStream = new FileInputStream(pdfContent);
 ```
 
-#### postage (optional)
+##### postage (optional)
 
 You can choose first or second class postage for your precompiled letter. Set the value to first for first class, or second for second class. If you do not pass in this argument, the postage will default to second class.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `LetterResponse`:
 
@@ -524,7 +524,7 @@ String reference;
 String postage
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -543,13 +543,13 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`400`|`"message":"reference cannot be null or empty"`|Populate the reference parameter|
 |`400`|`"message":"precompiledPDF cannot be null or empty"`|Send a PDF file with data in it|
 
-# Get message status
+## Get message status
 
 Message status depends on the type of message you have sent.
 
 You can only get the status of messages that are 7 days old or newer.
 
-## Status - email
+### Status - email
 
 |Status|Information|
 |:---|:---|
@@ -558,7 +558,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again."|
 
-## Status - text message
+### Status - text message
 
 |Status|Information|
 |:---|:---|
@@ -569,7 +569,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Delivered|The message was successfully delivered.|
 |Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
 
-## Status - letter
+### Status - letter
 
 |Status|information|
 |:---|:---|
@@ -577,7 +577,7 @@ You can only get the status of messages that are 7 days old or newer.
 |Accepted|GOV.UK Notify has sent the letter to the provider to be printed.|
 |Received|The provider has printed and dispatched the letter.|
 
-## Status - precompiled letter
+### Status - precompiled letter
 
 |Status|information|
 |:---|:---|
@@ -585,24 +585,24 @@ You can only get the status of messages that are 7 days old or newer.
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |Validation failed|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf) for more information.|
 
-## Get the status of one message
+### Get the status of one message
 
-### Method
+#### Method
 
 ```java
 Notification notification = client.getNotificationById(notificationId);
 ```
 
-### Arguments
+#### Arguments
 
-#### notificationId (required)
+##### notificationId (required)
 
 The ID of the notification. To find the notification ID, you can either:
 
 * check the response to the [original notification method call](#response)
 * [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Notification`:
 
@@ -633,7 +633,7 @@ Optional<DateTime> estimatedDelivery;
 Optional<String> createdByName;
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -645,13 +645,13 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
 
 
-## Get the status of multiple messages
+### Get the status of multiple messages
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the [`olderThanId`](#olderthanid-optional) argument.
 
 You can only get the status of messages that are 7 days old or newer.
 
-### Method
+#### Method
 
 ```java
 NotificationList notification = client.getNotifications(
@@ -666,11 +666,11 @@ To get the most recent messages, you must pass in an empty `olderThanId` argumen
 
 To get older messages, pass the ID of an older notification into the `olderThanId` argument. This returns the next oldest messages from the specified notification ID.
 
-### Arguments
+#### Arguments
 
 You can pass in empty arguments or `null` to ignore these filters.
 
-#### status (optional)
+##### status (optional)
 
 You can filter by each:
 
@@ -681,7 +681,7 @@ You can filter by each:
 
 You can leave out this argument to ignore this filter.
 
-#### notificationType (optional)
+##### notificationType (optional)
 
 You can filter by:
 
@@ -689,7 +689,7 @@ You can filter by:
 * `sms`
 * `letter`
 
-#### reference (optional)
+##### reference (optional)
 
 A unique identifier you create if necessary. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
@@ -697,7 +697,7 @@ A unique identifier you create if necessary. This reference identifies a single 
 String reference='STRING';
 ```
 
-#### olderThanId (optional)
+##### olderThanId (optional)
 
 Input the ID of a notification into this argument. If you use this argument, the client returns the next 250 received notifications older than the given ID.
 
@@ -707,7 +707,7 @@ String olderThanId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 
 If you pass in an empty argument or `null`, the client returns the most recent 250 notifications.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `NotificationList`:
 
@@ -717,7 +717,7 @@ String currentPageLink;
 Optional<String> nextPageLink;
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -729,9 +729,9 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
 
-## Get a PDF for a letter notification
+### Get a PDF for a letter notification
 
-### Method
+#### Method
 
 This returns the PDF contents of a letter notification.
 
@@ -739,20 +739,20 @@ This returns the PDF contents of a letter notification.
 byte[] pdfFile = client.getPdfForLetter(notificationId)
 ```
 
-### Arguments
+#### Arguments
 
-#### notificationId (required)
+##### notificationId (required)
 
 The ID of the notification. To find the notification ID, you can either:
 
 * check the response to the [original notification method call](#get-the-status-of-one-message-response)
 * [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page
 
-### Response
+#### Response
 
 If the request to the client is successful, the client will return a `byte[]` object containing the raw PDF data.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -768,11 +768,11 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
 
 
-# Get a template
+## Get a template
 
-## Get a template by ID
+### Get a template by ID
 
-### Method
+#### Method
 
 This returns the latest version of the template.
 
@@ -780,9 +780,9 @@ This returns the latest version of the template.
 Template template = client.getTemplateById(templateId);
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
 
@@ -790,7 +790,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 String templateId='f33517ff-2a88-4f6e-b855-c550268ce08a';
 ```
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Template`:
 
@@ -808,7 +808,7 @@ Optional<Map<String, Object>> personalisation;
 Optional<String> letterContactBlock;
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -819,17 +819,17 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-arguments-templateid-required)|
 
 
-## Get a template by ID and version
+### Get a template by ID and version
 
-### Method
+#### Method
 
 ```java
 Template template = client.getTemplateVersion(templateId, version);
 ```
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
 
@@ -837,11 +837,11 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 String templateId='f33517ff-2a88-4f6e-b855-c550268ce08a';
 ```
 
-#### version (required)
+##### version (required)
 
 The version number of the template.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `Template`:
 
@@ -859,7 +859,7 @@ Optional<Map<String, Object>> personalisation;
 Optional<String> letterContactBlock;
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -871,9 +871,9 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No Result Found"`<br>`}]`|Check your [template ID](#get-a-template-by-id-and-version-arguments-templateid-required) and [version](#version-required)|
 
 
-## Get all templates
+### Get all templates
 
-### Method
+#### Method
 
 This returns the latest version of all templates.
 
@@ -881,9 +881,9 @@ This returns the latest version of all templates.
 TemplateList templates = client.getAllTemplates(templateType);
 ```
 
-### Arguments
+#### Arguments
 
-#### templateType (optional)
+##### templateType (optional)
 
 If you do not use `templateType`, the client returns all templates. Otherwise you can filter by:
 
@@ -891,7 +891,7 @@ If you do not use `templateType`, the client returns all templates. Otherwise yo
 - `sms`
 - `letter`
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `TemplateList`:
 
@@ -901,9 +901,9 @@ List<Template> templates;
 
 If no templates exist for a template type or there no templates for a service, the templates list is empty.
 
-## Generate a preview template
+### Generate a preview template
 
-### Method
+#### Method
 
 This generates a preview version of a template.
 
@@ -916,9 +916,9 @@ TemplatePreview templatePreview = client.getTemplatePreview(
 
 The parameters in the personalisation argument must match the placeholder fields in the actual template. The API notification client ignores any extra fields in the method.
 
-### Arguments
+#### Arguments
 
-#### templateId (required)
+##### templateId (required)
 
 The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __Templates__ page to find it.
 
@@ -926,7 +926,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 String templateId='f33517ff-2a88-4f6e-b855-c550268ce08a';
 ```
 
-#### personalisation (required)
+##### personalisation (required)
 
 If a template has placeholder fields for personalised information such as name or application date, you must provide their values in a map. For example:
 
@@ -937,7 +937,7 @@ personalisation.put("application_date", "2018-01-01");
 ```
 If a template does not have any placeholder fields for personalised information, you must pass in an empty map or `null`.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `TemplatePreview`:
 
@@ -950,7 +950,7 @@ Optional<String> subject;
 Optional<String> html;
 ```
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 
@@ -962,7 +962,7 @@ If the request is not successful, the client returns a `NotificationClientExcept
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
 
-# Get received text messages
+## Get received text messages
 
 This API call returns one page of up to 250 received text messages. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the [`olderThanId`](#get-a-page-of-received-text-messages-arguments-olderthanid-optional) argument.
 
@@ -970,13 +970,13 @@ You can only get messages that are 7 days old or newer.
 
 You can also set up [callbacks](#callbacks) for received text messages.
 
-## Enable received text messages
+### Enable received text messages
 
 Contact the GOV.UK Notify team using the [support page](https://www.notifications.service.gov.uk/support) or [chat to us on Slack](https://ukgovernmentdigital.slack.com/messages/C0E1ADVPC) to request a unique number for text message replies.
 
-## Get a page of received text messages
+### Get a page of received text messages
 
-### Method
+#### Method
 
 ```java
 ReceivedTextMessageList response = client.getReceivedTextMessages(olderThanId);
@@ -986,9 +986,9 @@ To get the most recent messages, you must pass in an empty argument or `null`.
 
 To get older messages, pass the ID of an older notification into the `olderThanId` argument. This returns the next oldest messages from the specified notification ID.
 
-### Arguments
+#### Arguments
 
-#### olderThanId (optional)
+##### olderThanId (optional)
 
 Input the ID of a received text message into this argument. If you use this argument, the client returns the next 250 received text messages older than the given ID.
 
@@ -998,7 +998,7 @@ String olderThanId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 
 If you pass in an empty argument or `null`, the client returns the most recent 250 text messages.
 
-### Response
+#### Response
 
 If the request to the client is successful, the client returns a `ReceivedTextMessageList` that returns all received texts.
 
@@ -1019,7 +1019,7 @@ private DateTime createdAt;
 ```
 If the notification specified in the `olderThanId` argument is older than 7 days, the client returns an empty response.
 
-### Error codes
+#### Error codes
 
 If the request is not successful, the client returns a `NotificationClientException` containing the relevant error code:
 


### PR DESCRIPTION
This changes the headings so that there is only one H1 heading. This is part of the work to make the tech docs headings accessible.
