### PR TITLE
Release to maven central

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,15 @@ Increment the version in the `src/main/resources/application.properties` and `po
 ## Deploying
 
 [For internal notify use only]
-Make sure your `~/.m2/settings.xml` file is up to date with the file found at `credentials/bintray/settings.xml` and you have updated the versions in the required files.
+You'll need to make sure you have the `notify-gpg-key` private key available locally.
+
+```shell
+gpg --import <(notify-pass show credentials/concourse/gpg-key)
+```
 
 Then, from the notifications-java-client directory, run
 
 ```shell
+export MAVEN_CENTRAL_PASSWORD=$(notify-pass show credentials/maven-central/password)
 ./deploy.sh
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,12 +6,12 @@ This documentation is for developers interested in using the GOV.UK Notify Java 
 
 ### Install the client
 
-The `notifications-java-client` deploys to Bintray.
+The `notifications-java-client` deploys to Maven Central.
 
-Go to the [GOV.UK Notify Java client page on Bintray](https://bintray.com/gov-uk-notify/maven/notifications-java-client) [external link]:
+Go to the [GOV.UK Notify Java client page on Maven Central](https://search.maven.org/artifact/uk.gov.service.notify/notifications-java-client) [external link]:
 
-1. Select __Set me up!__ and use the appropriate download instructions.
-1. Go to the Maven build settings section of the page and copy the appropriate dependency code snippet.
+1. Select the most recent version.
+1. Copy the dependency configuration snippet for your build tool.
 
 Refer to the [client changelog](https://github.com/alphagov/notifications-java-client/blob/master/CHANGELOG.md) for the version number and the latest updates.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,4 +4,12 @@ set -eo pipefail
 
 source environment.sh
 
-mvn clean javadoc:jar source:jar deploy
+if [[ -z "${MAVEN_CENTRAL_PASSWORD}" ]]; then
+  # notify-pass is set up by our bash_profile/bashrc/etc files, so isnt available within this shell. have to do the
+  # hard work manually
+  echo 'Maven password not set. Please run the following and then retry'
+  echo 'export MAVEN_CENTRAL_PASSWORD=$(notify-pass show credentials/maven-central/password)'
+  exit 1
+fi
+
+mvn --setings=maven-settings.xml clean javadoc:jar source:jar deploy

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -1,0 +1,10 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<servers>
+		<server>
+		    <id>ossrh</id>
+		    <username>govuknotify</username>
+		    <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+		</server>
+	</servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
     <version>3.17.0-RELEASE</version>
+    <packaging>jar</packaging>
+    
+    <name>GOV.UK Notify Java client</name>
+    <description>Use this client to send emails, text messages and letters using the GOV.UK Notify API.</description>
+    <url>http://www.notifications.service.gov.uk</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>GOV.UK Notify Team</name>
+            <email>notify-support@digital.cabinet-office.gov.uk</email>
+            <organization>Government Digital Service</organization>
+            <organizationUrl>https://www.gov.uk/government/organisations/government-digital-service</organizationUrl>
+        </developer>
+    </developers>
+    
+    <scm>
+        <connection>scm:git:git://github.com/alphagov/notifications-java-client.git</connection>
+        <developerConnection>scm:git:ssh://github.com:alphagov/notifications-java-client.git</developerConnection>
+        <url>http://github.com/alphagov/notifications-java-client/tree/master</url>
+    </scm>
+    
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -23,7 +52,6 @@
             <version>3.4.4</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
@@ -61,10 +89,13 @@
         </dependency>
     </dependencies>
     <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
         <repository>
-            <id>bintray-gov-uk-notify-maven</id>
-            <name>gov-uk-notify-maven</name>
-            <url>https://api.bintray.com/maven/gov-uk-notify/maven/notifications-java-client/;publish=1</url>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
     <build>
@@ -105,7 +136,9 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
@@ -125,6 +158,50 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <keyname>6C83F0C698B034FAAAD07127FC05486C1A0F431A</keyname>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <!--
+                        set autoReleaseAfterClose to false if you want to push to maven's
+                        staging area but not release the package. For details see
+                        https://central.sonatype.org/pages/releasing-the-deployment.html
+                    -->
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
     <version>3.17.0-RELEASE</version>
     <properties>
-       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-       <maven.compiler.source>1.8</maven.compiler.source>
-       <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
@@ -79,55 +77,55 @@
                 </includes>
             </resource>
         </resources>
-    <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.1</version>
-            <executions>
-                <execution>
-                    <id>attach-sources</id>
-                    <goals>
-                        <goal>jar</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.1.0</version>
-            <executions>
-                <execution>
-                    <id>attach-javadocs</id>
-                    <goals>
-                        <goal>jar</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-        <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-                <useSystemClassLoader>false</useSystemClassLoader>
-            </configuration>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <version>3.0.0-M3</version>
-            <configuration>
-                <useSystemClassLoader>false</useSystemClassLoader>
-            </configuration>
-            <executions>
-                <execution>
-                    <goals>
-                        <goal>integration-test</goal>
-                        <goal>verify</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-    </plugins>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
Look, here it is! https://repo1.maven.org/maven2/uk/gov/service/notify/notifications-java-client/

Deploy to maven central rather than bintray. For now, this is still done manually, using the same `./deploy.sh` script as before.

This page explains all the bits we needed to add to the pom.xml to meet maven central's more stringent requirements on metadata (descriptions, license info, etc). See https://central.sonatype.org/pages/requirements.html#sufficient-metadata.

### GPG signing

We now sign our artifacts with the notify gpg key, stored at `notify-pass show credentials/concourse/gpg-key`.

You can verify this like so:

```
> curl -sflL 'https://repo1.maven.org/maven2/uk/gov/service/notify/notifications-java-client/3.17.0-RELEASE/notifications-java-client-3.17.0-RELEASE.pom' > release.pom
> curl -sflL 'https://repo1.maven.org/maven2/uk/gov/service/notify/notifications-java-client/3.17.0-RELEASE/notifications-java-client-3.17.0-RELEASE.pom.asc' > release.pom.asc
> gpg --verify release.pom.asc
gpg: Signature made Mon 29 Mar 18:04:39 2021 BST
gpg:                using RSA key 6C83F0C698B034FAAAD07127FC05486C1A0F431A
gpg: Good signature from "notify-concourse-gpg-key (GPG key for concourse builds) <notify-support+concourse@didgital.cabinet-office.gov.uk>" [ultimate]
```

I've also removed `settings.xml` from creds, because it encourages you to leave the password to maven in plaintext in your user folder. Instead I've added a maven-settings.xml template, and now if you wish to deploy, you'll need to run:

```sh
export MAVEN_CENTRAL_PASSWORD=$(notify-pass show credentials/maven-central/password)'
./deploy.sh
```