### PR TITLE
Upgrade dependencies to fix CVE-2021-29425 on commons-io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.17.2-RELEASE
+* Updated dependencies to latest versions
+
 ## 3.17.1-RELEASE
 * Minor patch release, changes to pom.xml including adding a license, contact details and more.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.17.1-RELEASE</version>
+    <version>3.17.2-RELEASE</version>
     <packaging>jar</packaging>
     
     <name>GOV.UK Notify Java client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -43,19 +43,19 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.4.4</version>
+            <version>3.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.6.5</version>
+            <version>0.7.7</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -65,27 +65,27 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20180813</version>
+            <version>20210307</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.10.1</version>
+            <version>2.10.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.8</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.12.0</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.17.1-RELEASE
+project.version=3.17.2-RELEASE


### PR DESCRIPTION
## What problem does the pull request solve?
The current version ships with a commons-io library that is 3 years old that is affected by security CVE-2021-29425.  This then means that our OWASP checks in our project fail unless we explicitly override the transient dependency.

I updated all the dependencies to the latest versions by running:
```
mvn versions:use-latest-releases
```
I've opted for a patch version update.

## Checklist
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve update the changelog (in `CHANGELOG.md`)
- [x] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `pom.xml`
