### PR TITLE
Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.17.2-RELEASE
+* Updated dependencies to latest versions
+
 ## 3.17.1-RELEASE
 * Minor patch release, changes to pom.xml including adding a license, contact details and more.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Pull requests are welcome.
 
 ## Unit tests
 
-On a command line build the project with Maven to run the unit tests and integration tests:
+On a command line build the project with Maven to run the unit tests:
 
 ```shell
 > mvn clean test
@@ -13,39 +13,26 @@ On a command line build the project with Maven to run the unit tests and integra
 
 ## Integration Tests for Notify dev team
 
-You will need to source an environment.sh file. The contents of that file are explained below. All secrets are found in the jenkins vault, stored in ansible in the notifications-aws repo.
+You will need to source an environment.sh file. You can find a copy in notify-pass credentials/client-integration-tests. You will also need to include the following variable.
 
-```
+```shell
 export NOTIFY_API_URL=https://api.notify.works
-export API_KEY= # vault_jenkins_notify_client.api_key
-export FUNCTIONAL_TEST_EMAIL=notify-tests-preview+client_funct_tests@digital.cabinet-office.gov.uk
-export FUNCTIONAL_TEST_NUMBER=+447537417379 # Twilio number
-export EMAIL_TEMPLATE_ID=f0bb62f7-5ddb-4bf8-aac7-c1e6aefd1524
-export SMS_TEMPLATE_ID=31046c06-418a-49bf-86de-706b68415b47
-export LETTER_TEMPLATE_ID=de1252c4-d8c3-4435-92fb-02f136778b2b
-export EMAIL_REPLY_TO_ID=db8d1a9d-41ef-43cd-a04a-ed7d95214d95
-export SMS_SENDER_ID=e9355456-c52f-4648-abb6-5fc192b29195
-export INBOUND_SMS_QUERY_KEY= # vault_jenkins_notify_client.inbound_sms_query_key
-export API_SENDING_KEY= # vault_jenkins_notify_client.api_sending_key
 ```
 
-
-## Update version
-Increment the version in the `src/main/resources/application.properties` and `pom.xml` files.
-
-
-## Deploying
-
-[For internal notify use only]
-You'll need to make sure you have the `notify-gpg-key` private key available locally.
+Use the following command to run the integration tests:
+```shell
+mvn clean verify
+```
+NOTE: you'll get a build failure `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:1.5:sign (sign-artifacts) on project notifications-java-client: Exit code: 2 -> [Help 1]
+` unless you import the gpg key, however, the you should see if the integration tests failed in the log message before the error. Import the key with this command:
 
 ```shell
 gpg --import <(notify-pass show credentials/concourse/gpg-key)
 ```
 
-Then, from the notifications-java-client directory, run
+## Update version
+Increment the version in the `src/main/resources/application.properties` and `pom.xml` files.
 
-```shell
-export MAVEN_CENTRAL_PASSWORD=$(notify-pass show credentials/maven-central/password)
-./deploy.sh
-```
+## Deploying
+
+Run the `release-java-client` concourse job after the `build-and-deploy-tech-docs-preview` is complete to publish the java client to maven central.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Pull requests are welcome.
 On a command line build the project with Maven to run the unit tests:
 
 ```shell
-> mvn clean test
+> make test
 ```
 
 
@@ -21,18 +21,14 @@ export NOTIFY_API_URL=https://api.notify.works
 
 Use the following command to run the integration tests:
 ```shell
-mvn clean verify
+make integration-test
 ```
 NOTE: you'll get a build failure `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:1.5:sign (sign-artifacts) on project notifications-java-client: Exit code: 2 -> [Help 1]
-` unless you import the gpg key, however, the you should see if the integration tests failed in the log message before the error. Import the key with this command:
-
-```shell
-gpg --import <(notify-pass show credentials/concourse/gpg-key)
-```
+` however, you should see if the integration tests passed in the log message before the error. 
 
 ## Update version
 Increment the version in the `src/main/resources/application.properties` and `pom.xml` files.
 
 ## Deploying
 
-Run the `release-java-client` concourse job after the `build-and-deploy-tech-docs-preview` is complete to publish the java client to maven central.
+Concourse will release and publish the java client to maven central

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: ## Run tests
 
 .PHONY: integration-test
 integration-test: ## Run integration tests
-	mvn --batch-mode clean verify
+	mvn --batch-mode clean integration-test
 
 .PHONY: generate-env-file
 generate-env-file: ## Generate the environment file for running the tests inside a Docker container

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
                         staging area but not release the package. For details see
                         https://central.sonatype.org/pages/releasing-the-deployment.html
                     -->
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.17.1-RELEASE</version>
+    <version>3.17.2-RELEASE</version>
     <packaging>jar</packaging>
     
     <name>GOV.UK Notify Java client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -43,19 +43,19 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.4.4</version>
+            <version>3.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>0.6.5</version>
+            <version>0.7.7</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -65,27 +65,27 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20180813</version>
+            <version>20210307</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.10.1</version>
+            <version>2.10.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.8</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.12.0</version>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.17.1-RELEASE
+project.version=3.17.2-RELEASE


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
The current version ships with a commons-io library that is 3 years old that is affected by security CVE-2021-29425. This then means that our OWASP checks in our project fail unless we explicitly override the transient dependency.

I updated all the dependencies to the latest versions by running:

`mvn versions:use-latest-releases`

I've opted for a patch version update.

PR contributed by @petergphillips  - thank you from the Notify Team

@servingUpAces  has run unit and integration tests locally. also made an update to the CONTRIBUTING.MD

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [X ] I’ve update the documentation (in `DOCUMENTATION.md`)
- [X ] I’ve bumped the version number
    - [X ] in `src/main/resources/application.properties`
    - [ X] in `pom.xml`
