### PR TITLE
remove email from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <developers>
         <developer>
             <name>GOV.UK Notify Team</name>
-            <email>notify-support@digital.cabinet-office.gov.uk</email>
+            <url>http://www.notifications.service.gov.uk/support</url>
             <organization>Government Digital Service</organization>
             <organizationUrl>https://www.gov.uk/government/organisations/government-digital-service</organizationUrl>
         </developer>


### PR DESCRIPTION
we don't want to be advertising our email (it currently reads this field and shows up on maven search). instead, replace it with our support page, so any queries end up in our tickets and not lost in the inbox aether


