### PR TITLE
Remove commons-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.17.3-RELEASE
+* Removed unused commons-cli dependency
+
 ## 3.17.2-RELEASE
 * Updated dependencies to latest versions
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,6 @@
             <version>0.7.7</version>
         </dependency>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20210307</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.17.2-RELEASE</version>
+    <version>3.17.3-RELEASE</version>
     <packaging>jar</packaging>
-    
+
     <name>GOV.UK Notify Java client</name>
     <description>Use this client to send emails, text messages and letters using the GOV.UK Notify API.</description>
     <url>http://www.notifications.service.gov.uk</url>
@@ -26,13 +26,13 @@
             <organizationUrl>https://www.gov.uk/government/organisations/government-digital-service</organizationUrl>
         </developer>
     </developers>
-    
+
     <scm>
         <connection>scm:git:git://github.com/alphagov/notifications-java-client.git</connection>
         <developerConnection>scm:git:ssh://github.com:alphagov/notifications-java-client.git</developerConnection>
         <url>http://github.com/alphagov/notifications-java-client/tree/master</url>
     </scm>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.17.2-RELEASE
+project.version=3.17.3-RELEASE


### PR DESCRIPTION
It's an unused dependency, and that version has several outstanding CVEs.
Lets just remove the whole thing

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `pom.xml`
