### PR TITLE
Feature: Introduce an overload of prepareUpload that uses a Class for retentionPeriod

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -393,9 +393,15 @@ client.sendEmail(templateId,
 
 Set the number of weeks you want the file to be available using the `retention_period` parameter.
 
-You can choose any value between 1 week and 78 weeks.
-
 To use this feature will need version 3.18.0-RELEASE of the Java client library, or a more recent version.
+
+You can choose any value between 1 week and 78 weeks. The value can be passed in as a `String`,
+or as of version 3.19.0-RELEASE a `RetentionPeriodDuration(Integer, ChronoUnit)`. 
+
+If you are dynamically assigning `retention_period`,
+using `RetentionPeriodDuration` is recommended to take advantage of the validation it performs on construction;
+an `IllegalArgumentException` is thrown if validation fails. Currently, only `ChronoUnit.WEEKS` is a supported value 
+for unit.
 
 If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
 
@@ -405,7 +411,33 @@ File file = new File(classLoader.getResource("document_to_upload.pdf").getFile()
 byte [] fileContents = FileUtils.readFileToByteArray(file);
 
 HashMap<String, Object> personalisation = new HashMap();
-personalisation.put("link_to_file", client.prepareUpload(fileContents, false, false, "52 weeks"));
+personalisation.put("link_to_file", 
+                    client.prepareUpload(
+                            fileContents, 
+                            false, 
+                            false, 
+                            "52 weeks"
+                    ));
+client.sendEmail(templateId,
+                 emailAddress,
+                 personalisation,
+                 reference,
+                 emailReplyToId);
+```
+
+```java
+ClassLoader classLoader = getClass().getClassLoader();
+File file = new File(classLoader.getResource("document_to_upload.pdf").getFile());
+byte [] fileContents = FileUtils.readFileToByteArray(file);
+
+HashMap<String, Object> personalisation = new HashMap();
+personalisation.put("link_to_file", 
+                    client.prepareUpload(
+                            fileContents, 
+                            false, 
+                            false, 
+                            new RetentionPeriodDuration(52, ChronoUnit.WEEKS)
+                    ));
 client.sendEmail(templateId,
                  emailAddress,
                  personalisation,

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -398,10 +398,9 @@ To use this feature will need version 3.18.0-RELEASE of the Java client library,
 You can choose any value between 1 week and 78 weeks. The value can be passed in as a `String`,
 or as of version 3.19.0-RELEASE a `RetentionPeriodDuration(Integer, ChronoUnit)`. 
 
-If you are dynamically assigning `retention_period`,
-using `RetentionPeriodDuration` is recommended to take advantage of the validation it performs on construction;
-an `IllegalArgumentException` is thrown if validation fails. Currently, only `ChronoUnit.WEEKS` is a supported value 
-for unit.
+If you want to dynamically assign the value for `retention_period`,
+using `RetentionPeriodDuration` is recommended to avoid having to deal with string . Currently, only `ChronoUnit.WEEKS` 
+is a supported value for unit.
 
 If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.18.0-RELEASE</version>
+    <version>3.19.0-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>GOV.UK Notify Java client</name>

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -10,12 +10,10 @@ import org.json.JSONObject;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
@@ -351,6 +349,28 @@ public class NotificationClient implements NotificationClientApi {
      */
     public static JSONObject prepareUpload(final byte[] documentContents) throws NotificationClientException {
         return prepareUpload(documentContents, false);
+    }
+
+    /**
+     * Use the prepareUpload method when uploading a document via sendEmail.
+     * The prepareUpload method creates a <code>JSONObject</code> which will need to be added to the personalisation map.
+     *
+     * This version of the class overloads prepareUpload to allow for the use of the RetentionPeriodDuration class if
+     * desired.
+     * @see RetentionPeriodDuration
+     *
+     * @param documentContents byte[] of the document
+     * @param isCsv boolean True if a CSV file, False if not to ensure document is downloaded as correct file type
+     * @param confirmEmailBeforeDownload boolean True to require the user to enter their email address before accessing the file
+     * @param retentionPeriodDuration a RetentionPeriodDuration that defines how long a file is held for
+     * @return <code>JSONObject</code> a json object to be added to the personalisation is returned
+     */
+    public static JSONObject prepareUpload(final byte[] documentContents,
+                                           boolean isCsv,
+                                           boolean confirmEmailBeforeDownload,
+                                           RetentionPeriodDuration retentionPeriodDuration
+    ) throws NotificationClientException {
+        return prepareUpload(documentContents, isCsv, confirmEmailBeforeDownload, retentionPeriodDuration.toString());
     }
 
     private String performPostRequest(HttpURLConnection conn, JSONObject body, int expectedStatusCode) throws NotificationClientException {

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -362,15 +362,15 @@ public class NotificationClient implements NotificationClientApi {
      * @param documentContents byte[] of the document
      * @param isCsv boolean True if a CSV file, False if not to ensure document is downloaded as correct file type
      * @param confirmEmailBeforeDownload boolean True to require the user to enter their email address before accessing the file
-     * @param retentionPeriodDuration a RetentionPeriodDuration that defines how long a file is held for
+     * @param retentionPeriod a RetentionPeriodDuration that defines how long a file is held for
      * @return <code>JSONObject</code> a json object to be added to the personalisation is returned
      */
     public static JSONObject prepareUpload(final byte[] documentContents,
                                            boolean isCsv,
                                            boolean confirmEmailBeforeDownload,
-                                           RetentionPeriodDuration retentionPeriodDuration
+                                           RetentionPeriodDuration retentionPeriod
     ) throws NotificationClientException {
-        return prepareUpload(documentContents, isCsv, confirmEmailBeforeDownload, retentionPeriodDuration.toString());
+        return prepareUpload(documentContents, isCsv, confirmEmailBeforeDownload, retentionPeriod.toString());
     }
 
     private String performPostRequest(HttpURLConnection conn, JSONObject body, int expectedStatusCode) throws NotificationClientException {

--- a/src/main/java/uk/gov/service/notify/RetentionPeriodDuration.java
+++ b/src/main/java/uk/gov/service/notify/RetentionPeriodDuration.java
@@ -15,12 +15,11 @@ public class RetentionPeriodDuration {
      * @param amount - The amount of units of time. Example: If unit is ChronoUnit.WEEKS, and amount is 52,
      *               then the duration is 52 weeks.
      * @param unit - The unit of time that is being represented as a ChronoUnit. Currently only supports
-     *             ChronoUnit.WEEKS until API changes allow for other unit types
+     *             ChronoUnit.WEEKS until API changes allow for other unit types.
      */
     public RetentionPeriodDuration(int amount, ChronoUnit unit) {
         this.amount = amount;
         this.unit = unit;
-        validate();
     }
 
     public int getAmount() {
@@ -29,30 +28,6 @@ public class RetentionPeriodDuration {
 
     public ChronoUnit getUnit() {
         return unit;
-    }
-
-    /***
-     * Validates the object; this should be run when the object is constructed
-     * @throws IllegalArgumentException - This is thrown whenever either amount or unit are considered invalid
-     */
-    public void validate(){
-        if(this.unit == ChronoUnit.WEEKS){
-            if(this.amount < 1 || this.amount > 78){
-                throw new IllegalArgumentException(
-                        "When unit is ChronoUnit.WEEKS, value must be larger than 0 and smaller than 79"
-                );
-            }
-        } else {
-            // Currently only Weeks is supported by the API; this can be updated when
-            // API changes allows for different values, or specifically when DAYS is added (as then we can
-            // convert times to days with ChronoUnit
-            throw new IllegalArgumentException(
-                    String.format(
-                            "%s is not a valid unit. Only ChronoUnit.WEEKS is currently supported.",
-                            this.unit.name()
-                    )
-            );
-        }
     }
 
     /***

--- a/src/main/java/uk/gov/service/notify/RetentionPeriodDuration.java
+++ b/src/main/java/uk/gov/service/notify/RetentionPeriodDuration.java
@@ -1,0 +1,71 @@
+package uk.gov.service.notify;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
+/***
+ * Represents a retention period duration for files for file upload
+ */
+public class RetentionPeriodDuration {
+    private final int amount;
+    private final ChronoUnit unit;
+
+    /***
+     * Creates an employee with the specified name and
+     * @param amount - The amount of units of time. Example: If unit is ChronoUnit.WEEKS, and amount is 52,
+     *               then the duration is 52 weeks.
+     * @param unit - The unit of time that is being represented as a ChronoUnit. Currently only supports
+     *             ChronoUnit.WEEKS until API changes allow for other unit types
+     */
+    public RetentionPeriodDuration(int amount, ChronoUnit unit) {
+        this.amount = amount;
+        this.unit = unit;
+        validate();
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public ChronoUnit getUnit() {
+        return unit;
+    }
+
+    /***
+     * Validates the object; this should be run when the object is constructed
+     * @throws IllegalArgumentException - This is thrown whenever either amount or unit are considered invalid
+     */
+    public void validate(){
+        if(this.unit == ChronoUnit.WEEKS){
+            if(this.amount < 1 || this.amount > 78){
+                throw new IllegalArgumentException(
+                        "When unit is ChronoUnit.WEEKS, value must be larger than 0 and smaller than 79"
+                );
+            }
+        } else {
+            // Currently only Weeks is supported by the API; this can be updated when
+            // API changes allows for different values, or specifically when DAYS is added (as then we can
+            // convert times to days with ChronoUnit
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s is not a valid unit. Only ChronoUnit.WEEKS is currently supported.",
+                            this.unit.name()
+                    )
+            );
+        }
+    }
+
+    /***
+     * The toString method converts the object into a string suitable for processing by the Notifications API
+     * @return A string, representing a retention period duration for files, that complies with the API's expectations
+     */
+    @Override
+    public String toString(){
+        // The unit has to be lower cased for the API to accept it
+        return String.format(
+                "%d %s",
+                getAmount(),
+                getUnit().toString().toLowerCase(Locale.ROOT)
+        );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.18.0-RELEASE
+project.version=3.19.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -11,6 +11,7 @@ import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.security.NoSuchAlgorithmException;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -120,9 +121,14 @@ public class NotificationClientTest {
     }
 
     @Test
-    public void testPrepareUploadWithEmailConfirmationAndRetentionPeriod() throws NotificationClientException {
+    public void testPrepareUploadWithEmailConfirmationAndRetentionPeriodString() throws NotificationClientException {
         byte[] documentContent = "this is a document to test with".getBytes();
-        JSONObject response = NotificationClient.prepareUpload(documentContent, true, true, "1 weeks");
+        JSONObject response = NotificationClient.prepareUpload(
+                documentContent,
+                true,
+                true,
+                "1 weeks"
+        );
         JSONObject expectedResult = new JSONObject();
         expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
         expectedResult.put("is_csv", true);
@@ -130,7 +136,33 @@ public class NotificationClientTest {
         expectedResult.put("retention_period", "1 weeks");
         assertEquals(expectedResult.getString("file"), response.getString("file"));
         assertEquals(expectedResult.getBoolean("is_csv"), response.getBoolean("is_csv"));
-        assertEquals(expectedResult.getBoolean("confirm_email_before_download"), response.getBoolean("confirm_email_before_download"));
+        assertEquals(
+                expectedResult.getBoolean("confirm_email_before_download"),
+                response.getBoolean("confirm_email_before_download")
+        );
+        assertEquals(expectedResult.getString("retention_period"), response.getString("retention_period"));
+    }
+
+    @Test
+    public void testPrepareUploadWithEmailConfirmationAndRetentionPeriodDuration() throws NotificationClientException {
+        byte[] documentContent = "this is a document to test with".getBytes();
+        JSONObject response = NotificationClient.prepareUpload(
+                documentContent,
+                true,
+                true,
+                new RetentionPeriodDuration(1, ChronoUnit.WEEKS)
+        );
+        JSONObject expectedResult = new JSONObject();
+        expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
+        expectedResult.put("is_csv", true);
+        expectedResult.put("confirm_email_before_download", true);
+        expectedResult.put("retention_period", "1 weeks");
+        assertEquals(expectedResult.getString("file"), response.getString("file"));
+        assertEquals(expectedResult.getBoolean("is_csv"), response.getBoolean("is_csv"));
+        assertEquals(
+                expectedResult.getBoolean("confirm_email_before_download"),
+                response.getBoolean("confirm_email_before_download")
+        );
         assertEquals(expectedResult.getString("retention_period"), response.getString("retention_period"));
     }
 

--- a/src/test/java/uk/gov/service/notify/RetentionPeriodDurationTest.java
+++ b/src/test/java/uk/gov/service/notify/RetentionPeriodDurationTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import java.time.temporal.ChronoUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class RetentionPeriodDurationTest {
 
@@ -15,56 +14,10 @@ public class RetentionPeriodDurationTest {
 
         assertEquals(52, duration.getAmount());
         assertEquals(ChronoUnit.WEEKS, duration.getUnit());
-
-        // We've already checked that the values are correctly inserted; here we check the edge cases that are
-        // still valid. As a result, there are no asserts - this test will however fail if the validation during
-        // construction fails
-
-        new RetentionPeriodDuration(1, ChronoUnit.WEEKS);
-        new RetentionPeriodDuration(78, ChronoUnit.WEEKS);
     }
 
     @Test
-    public void testCreatingRetentionPeriodDuration_WithInvalidUnit(){
-        try {
-            new RetentionPeriodDuration(52, ChronoUnit.FOREVER);
-            fail("Did not get IllegalArgumentException");
-        } catch(IllegalArgumentException e) {
-            assertEquals(String.format(
-                    "%s is not a valid unit. Only ChronoUnit.WEEKS is currently supported.",
-                    ChronoUnit.FOREVER.name()
-            ), e.getMessage());
-        }
-    }
-
-    @Test
-    public void testCreatingRetentionPeriodDuration_WithInvalidAmount_Weeks_TooLow(){
-        try {
-            new RetentionPeriodDuration(0, ChronoUnit.WEEKS);
-            fail("Did not get IllegalArgumentException");
-        } catch(IllegalArgumentException e) {
-            assertEquals(
-                    "When unit is ChronoUnit.WEEKS, value must be larger than 0 and smaller than 79",
-                    e.getMessage()
-            );
-        }
-    }
-
-    @Test
-    public void testCreatingRetentionPeriodDuration_WithInvalidAmount_Weeks_TooHigh(){
-        try {
-            new RetentionPeriodDuration(79, ChronoUnit.WEEKS);
-            fail("Did not get IllegalArgumentException");
-        } catch(IllegalArgumentException e) {
-            assertEquals(
-                    "When unit is ChronoUnit.WEEKS, value must be larger than 0 and smaller than 79",
-                    e.getMessage()
-            );
-        }
-    }
-
-    @Test
-    public void testCreatingStringFromDuration_Weeks(){
+    public void testCreatingStringFromDuration(){
         RetentionPeriodDuration duration = new RetentionPeriodDuration(52, ChronoUnit.WEEKS);
         assertEquals("52 weeks", duration.toString());
     }

--- a/src/test/java/uk/gov/service/notify/RetentionPeriodDurationTest.java
+++ b/src/test/java/uk/gov/service/notify/RetentionPeriodDurationTest.java
@@ -1,0 +1,71 @@
+package uk.gov.service.notify;
+
+import org.junit.Test;
+
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class RetentionPeriodDurationTest {
+
+    @Test
+    public void testCreatingRetentionPeriodDuration_WithValidData(){
+        RetentionPeriodDuration duration = new RetentionPeriodDuration(52, ChronoUnit.WEEKS);
+
+        assertEquals(52, duration.getAmount());
+        assertEquals(ChronoUnit.WEEKS, duration.getUnit());
+
+        // We've already checked that the values are correctly inserted; here we check the edge cases that are
+        // still valid. As a result, there are no asserts - this test will however fail if the validation during
+        // construction fails
+
+        new RetentionPeriodDuration(1, ChronoUnit.WEEKS);
+        new RetentionPeriodDuration(78, ChronoUnit.WEEKS);
+    }
+
+    @Test
+    public void testCreatingRetentionPeriodDuration_WithInvalidUnit(){
+        try {
+            new RetentionPeriodDuration(52, ChronoUnit.FOREVER);
+            fail("Did not get IllegalArgumentException");
+        } catch(IllegalArgumentException e) {
+            assertEquals(String.format(
+                    "%s is not a valid unit. Only ChronoUnit.WEEKS is currently supported.",
+                    ChronoUnit.FOREVER.name()
+            ), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreatingRetentionPeriodDuration_WithInvalidAmount_Weeks_TooLow(){
+        try {
+            new RetentionPeriodDuration(0, ChronoUnit.WEEKS);
+            fail("Did not get IllegalArgumentException");
+        } catch(IllegalArgumentException e) {
+            assertEquals(
+                    "When unit is ChronoUnit.WEEKS, value must be larger than 0 and smaller than 79",
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testCreatingRetentionPeriodDuration_WithInvalidAmount_Weeks_TooHigh(){
+        try {
+            new RetentionPeriodDuration(79, ChronoUnit.WEEKS);
+            fail("Did not get IllegalArgumentException");
+        } catch(IllegalArgumentException e) {
+            assertEquals(
+                    "When unit is ChronoUnit.WEEKS, value must be larger than 0 and smaller than 79",
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testCreatingStringFromDuration_Weeks(){
+        RetentionPeriodDuration duration = new RetentionPeriodDuration(52, ChronoUnit.WEEKS);
+        assertEquals("52 weeks", duration.toString());
+    }
+}


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
- Currently, `prepareUpload` uses a `String` to represent the duration for `retentionPeriod`
- This can be quite awkward when developing in Java. If you're dynamically setting the `retentionPeriod`, you have to start performing string manipulation to get there, which is easy to get wrong. This problem could potentially get worse if you start to introduce other units of time aside from weeks
- It also perhaps isn't the best representation of time in Java, when things such as `ChronoUnit` are available to users, with a `String` being a relatively loose data type. If a developer were to write some code using prepareUpload, it would be easy for them to accidentally pass in a different string  without realising, or for the String being passed in before hand to be manipulated.

## What is the Solution?
- Introducing a strict Class helps to solve most of the issues above
- The new class, `RetentionPeriodDuration`, strictly takes an amount as an `Integer`, and a unit of time as a `ChronoUnit`.
- This solves the string manipulation problem; users now only have to manage integers and an enum, which is a lot simpler to manage in Java than the strings.
- It solves the issue of passing in the wrong string as it uses a unique Class
- After construction, the object is immutable (i.e. only getters are available), which solves the issue of the data being manipulated accidentally before being passed into `prepareUpload`
- This solution also would make it a lot easier to validate the values for the retention period up-front (instead of just at the Notifications API) if desired in the future
- It would also be possible to modify the class to allow most sensible values of `ChronoUnit` (e.g. Months / Years) if the days unit were to be added to the API in the future. This is because you could modify the constructor to convert the amount to days depending on the `ChronoUnit` (e.g. WEEKS would multiply the amount by 7).

## Other Notes
- This solution is completely backwards compatible. It overloads `prepareUpload` instead of replacing it (and for the most part uses the original function), so existing users of the function won't be affected and maintenance should be fairly simple
- I've written a complete unit testing set for the new class and updated some of the existing tests to check the overload works as expected
- As a result of the above, I've only moved the minor patch number. I have updated the documentation to reflect the new functionality.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `pom.xml`
