### PR TITLE
Bumps org.json to a version that is unaffected by CVE-2022-45688

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.19.1-RELEASE
+* Bump org.json to version 20230227. Although the Notify API client is unaffected by CVE-2022-45688, we bump this package to a version that fixes this vulnerability.
+
 ## 3.19.0-RELEASE
 * Adds a new interface for specifying custom retention periods when sending a file by email:
   * `retentionPeriod` can be set using a `new RetentionPeriodDuration(int, ChronoUnit)`

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>3.19.0-RELEASE</version>
+    <version>3.19.1-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>GOV.UK Notify Java client</name>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20210307</version>
+            <version>20230227</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=3.19.0-RELEASE
+project.version=3.19.1-RELEASE


### PR DESCRIPTION
We don't do any XML parsing in the client anyway but this change will
- make sure if we ever did, we would not be affected
- remove any warnings for a security vulnerability in our API client which may be reported by users or worry our users

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `pom.xml`
