### PR TITLE
Fix method name in docs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -994,7 +994,7 @@ If no templates exist for a template type or there no templates for a service, t
 This generates a preview version of a template.
 
 ```java
-TemplatePreview templatePreview = client.getTemplatePreview(
+TemplatePreview templatePreview = client.generateTemplatePreview(
     templateId,
     personalisation
 );

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -265,7 +265,7 @@ public class ClientIntegrationTestIT {
     }
 
     @Test
-    public void testGetTemplatePreview() throws NotificationClientException {
+    public void testGenerateTemplatePreview() throws NotificationClientException {
         NotificationClient client = getClient();
         HashMap<String, Object> personalisation = new HashMap<>();
         String uniqueName = UUID.randomUUID().toString();


### PR DESCRIPTION
This should be `generateTemplatePreview` and not `getTemplatePreview`.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation (in `DOCUMENTATION.md`)
- [ ] I’ve bumped the version number
    - [ ] in `src/main/resources/application.properties`
    - [ ] in `pom.xml`
