### PR TITLE
Allow setting custom filenames for documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.0-RELEASE
+* Remove the `isCsv` parameter to `prepareUpload`.
+* Add a `filename` parameter to `prepareUpload` to set the document's filename upon download. See our documentation for more specific guidance.
+
 ## 4.1.1-RELEASE
 * Bump json to 20231013 to address https://github.com/advisories/GHSA-4jq9-2xhw-jpx7.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -311,9 +311,22 @@ client.sendEmail(templateId,
                  emailReplyToId);
 ```
 
-##### CSV Files
+#### Set the filename
 
-Uploads for CSV files should use the `isCsv` parameter on the `prepareUpload()` function.  For example:
+To do this you will need version 5.0.0-RELEASE of the Java client library, or a more recent version.
+
+You should provide a filename when you upload your file.
+
+The filename should tell the recipient what the file contains. A memorable filename can help the recipient to find the file again later.
+
+The filename must end with a file extension. For example, `.csv` for a CSV file. If you include the wrong file extension, recipients may not be able to open your file.
+
+If you do not provide a filename for your file, Notify will:
+
+* generate a random filename
+* try to add the correct file extension
+
+If Notify cannot add the correct file extension, recipients may not be able to open your file.
 
 ```java
 ClassLoader classLoader = getClass().getClassLoader();
@@ -321,7 +334,7 @@ File file = new File(classLoader.getResource("document_to_upload.pdf").getFile()
 byte [] fileContents = FileUtils.readFileToByteArray(file);
 
 HashMap<String, Object> personalisation = new HashMap();
-personalisation.put("link_to_file", client.prepareUpload(fileContents, true));
+personalisation.put("link_to_file", client.prepareUpload(fileContents, "report.csv"));
 client.sendEmail(templateId,
                  emailAddress,
                  personalisation,

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>4.1.1-RELEASE</version>
+    <version>5.0.0-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>GOV.UK Notify Java client</name>

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -294,16 +294,24 @@ public class NotificationClient implements NotificationClientApi {
 
     /**
      * Use the prepareUpload method when uploading a document via sendEmail.
-     * The prepareUpload method creates a <code>JSONObject</code> which will need to be added to the personalisation map.
+     * The prepareUpload method creates a <code>JSONObject</code> which will need to
+     * be added to the personalisation map.
      *
-     * @param documentContents byte[] of the document
-     * @param isCsv boolean True if a CSV file, False if not to ensure document is downloaded as correct file type
-     * @param confirmEmailBeforeDownload boolean True to require the user to enter their email address before accessing the file
-     * @param retentionPeriod a string '[1-78] weeks' to change how long the document should be available to the user
-     * @return <code>JSONObject</code> a json object to be added to the personalisation is returned
+     * @param documentContents           byte[] of the document
+     * @param filename                   a string setting the filename of the
+     *                                   document upon download
+     * @param confirmEmailBeforeDownload boolean True to require the user to enter
+     *                                   their email address before accessing the
+     *                                   file
+     * @param retentionPeriod            a string '[1-78] weeks' to change how long
+     *                                   the document should be available to the
+     *                                   user
+     * @return <code>JSONObject</code> a json object to be added to the
+     *         personalisation is returned
      */
-    public static JSONObject prepareUpload(final byte[] documentContents, boolean isCsv, boolean confirmEmailBeforeDownload, String retentionPeriod) throws NotificationClientException {
-        if (documentContents.length > 2*1024*1024){
+    public static JSONObject prepareUpload(final byte[] documentContents, String filename,
+            boolean confirmEmailBeforeDownload, String retentionPeriod) throws NotificationClientException {
+        if (documentContents.length > 2 * 1024 * 1024) {
             throw new NotificationClientException(413, "File is larger than 2MB");
         }
         byte[] fileContentAsByte = Base64.encodeBase64(documentContents);
@@ -311,7 +319,7 @@ public class NotificationClient implements NotificationClientApi {
 
         JSONObject jsonFileObject = new JSONObject();
         jsonFileObject.put("file", fileContent);
-        jsonFileObject.put("is_csv", isCsv);
+        jsonFileObject.put("filename", filename);
         jsonFileObject.put("confirm_email_before_download", confirmEmailBeforeDownload);
         jsonFileObject.put("retention_period", retentionPeriod);
         return jsonFileObject;
@@ -319,14 +327,23 @@ public class NotificationClient implements NotificationClientApi {
 
     /**
      * Use the prepareUpload method when uploading a document via sendEmail.
-     * The prepareUpload method creates a <code>JSONObject</code> which will need to be added to the personalisation map.
+     * The prepareUpload method creates a <code>JSONObject</code> which will need to
+     * be added to the personalisation map.
      *
-     * @param documentContents byte[] of the document
-     * @param isCsv boolean True if a CSV file, False if not to ensure document is downloaded as correct file type
-     * @return <code>JSONObject</code> a json object to be added to the personalisation is returned
+     * @param documentContents           byte[] of the document
+     * @param confirmEmailBeforeDownload boolean True to require the user to enter
+     *                                   their email address before accessing the
+     *                                   file
+     * @param retentionPeriod            a string '[1-78] weeks' to change how long
+     *                                   the document should be available to the
+     *                                   user
+     * @return <code>JSONObject</code> a json object to be added to the
+     *         personalisation is returned
      */
-    public static JSONObject prepareUpload(final byte[] documentContents, boolean isCsv) throws NotificationClientException {
-        if (documentContents.length > 2*1024*1024){
+    public static JSONObject prepareUpload(final byte[] documentContents,
+            boolean confirmEmailBeforeDownload, RetentionPeriodDuration retentionPeriod)
+            throws NotificationClientException {
+        if (documentContents.length > 2 * 1024 * 1024) {
             throw new NotificationClientException(413, "File is larger than 2MB");
         }
         byte[] fileContentAsByte = Base64.encodeBase64(documentContents);
@@ -334,7 +351,34 @@ public class NotificationClient implements NotificationClientApi {
 
         JSONObject jsonFileObject = new JSONObject();
         jsonFileObject.put("file", fileContent);
-        jsonFileObject.put("is_csv", isCsv);
+        jsonFileObject.put("filename", JSONObject.NULL);
+        jsonFileObject.put("confirm_email_before_download", confirmEmailBeforeDownload);
+        jsonFileObject.put("retention_period", retentionPeriod.toString());
+        return jsonFileObject;
+    }
+
+    /**
+     * Use the prepareUpload method when uploading a document via sendEmail.
+     * The prepareUpload method creates a <code>JSONObject</code> which will need to
+     * be added to the personalisation map.
+     *
+     * @param documentContents byte[] of the document
+     * @param filename         a string setting the filename of the
+     *                         document upon download
+     * @return <code>JSONObject</code> a json object to be added to the
+     *         personalisation is returned
+     */
+    public static JSONObject prepareUpload(final byte[] documentContents, String filename)
+            throws NotificationClientException {
+        if (documentContents.length > 2 * 1024 * 1024) {
+            throw new NotificationClientException(413, "File is larger than 2MB");
+        }
+        byte[] fileContentAsByte = Base64.encodeBase64(documentContents);
+        String fileContent = new String(fileContentAsByte, ISO_8859_1);
+
+        JSONObject jsonFileObject = new JSONObject();
+        jsonFileObject.put("file", fileContent);
+        jsonFileObject.put("filename", filename);
         jsonFileObject.put("confirm_email_before_download", JSONObject.NULL);
         jsonFileObject.put("retention_period", JSONObject.NULL);
         return jsonFileObject;
@@ -342,35 +386,54 @@ public class NotificationClient implements NotificationClientApi {
 
     /**
      * Use the prepareUpload method when uploading a document via sendEmail.
-     * The prepareUpload method creates a <code>JSONObject</code> which will need to be added to the personalisation map.
+     * The prepareUpload method creates a <code>JSONObject</code> which will need to
+     * be added to the personalisation map.
      *
      * @param documentContents byte[] of the document
      * @return <code>JSONObject</code> a json object to be added to the personalisation is returned
      */
     public static JSONObject prepareUpload(final byte[] documentContents) throws NotificationClientException {
-        return prepareUpload(documentContents, false);
+        if (documentContents.length > 2 * 1024 * 1024) {
+            throw new NotificationClientException(413, "File is larger than 2MB");
+        }
+        byte[] fileContentAsByte = Base64.encodeBase64(documentContents);
+        String fileContent = new String(fileContentAsByte, ISO_8859_1);
+
+        JSONObject jsonFileObject = new JSONObject();
+        jsonFileObject.put("file", fileContent);
+        jsonFileObject.put("filename", JSONObject.NULL);
+        jsonFileObject.put("confirm_email_before_download", JSONObject.NULL);
+        jsonFileObject.put("retention_period", JSONObject.NULL);
+        return jsonFileObject;
     }
 
     /**
      * Use the prepareUpload method when uploading a document via sendEmail.
-     * The prepareUpload method creates a <code>JSONObject</code> which will need to be added to the personalisation map.
+     * The prepareUpload method creates a <code>JSONObject</code> which will need to
+     * be added to the personalisation map.
      *
-     * This version of the class overloads prepareUpload to allow for the use of the RetentionPeriodDuration class if
+     * This version of the class overloads prepareUpload to allow for the use of the
+     * RetentionPeriodDuration class if
      * desired.
+     *
      * @see RetentionPeriodDuration
      *
-     * @param documentContents byte[] of the document
-     * @param isCsv boolean True if a CSV file, False if not to ensure document is downloaded as correct file type
-     * @param confirmEmailBeforeDownload boolean True to require the user to enter their email address before accessing the file
-     * @param retentionPeriod a RetentionPeriodDuration that defines how long a file is held for
-     * @return <code>JSONObject</code> a json object to be added to the personalisation is returned
+     * @param documentContents           byte[] of the document
+     * @param filename                   a string setting the filename of the
+     *                                   document upon download
+     * @param confirmEmailBeforeDownload boolean True to require the user to enter
+     *                                   their email address before accessing the
+     *                                   file
+     * @param retentionPeriod            a RetentionPeriodDuration that defines how
+     *                                   long a file is held for
+     * @return <code>JSONObject</code> a json object to be added to the
+     *         personalisation is returned
      */
     public static JSONObject prepareUpload(final byte[] documentContents,
-                                           boolean isCsv,
-                                           boolean confirmEmailBeforeDownload,
-                                           RetentionPeriodDuration retentionPeriod
-    ) throws NotificationClientException {
-        return prepareUpload(documentContents, isCsv, confirmEmailBeforeDownload, retentionPeriod.toString());
+            String filename,
+            boolean confirmEmailBeforeDownload,
+            RetentionPeriodDuration retentionPeriod) throws NotificationClientException {
+        return prepareUpload(documentContents, filename, confirmEmailBeforeDownload, retentionPeriod.toString());
     }
 
     private String performPostRequest(HttpURLConnection conn, JSONObject body, int expectedStatusCode) throws NotificationClientException {

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -398,7 +398,6 @@ public class NotificationClient implements NotificationClientApi {
         }
         byte[] fileContentAsByte = Base64.encodeBase64(documentContents);
         String fileContent = new String(fileContentAsByte, ISO_8859_1);
-
         JSONObject jsonFileObject = new JSONObject();
         jsonFileObject.put("file", fileContent);
         jsonFileObject.put("filename", JSONObject.NULL);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=4.1.1-RELEASE
+project.version=5.0.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -100,24 +100,28 @@ public class NotificationClientTest {
         JSONObject response = NotificationClient.prepareUpload(documentContent);
         JSONObject expectedResult = new JSONObject();
         expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
-        expectedResult.put("is_csv", false);
+        expectedResult.put("filename", JSONObject.NULL);
         expectedResult.put("confirm_email_before_download", JSONObject.NULL);
         expectedResult.put("retention_period", JSONObject.NULL);
         assertEquals(expectedResult.getString("file"), response.getString("file"));
-        assertEquals(expectedResult.getBoolean("is_csv"), response.getBoolean("is_csv"));
+        assertEquals(response.optJSONObject("filename"), null);
+        assertEquals(response.optJSONObject("confirm_email_before_download"), null);
+        assertEquals(response.optJSONObject("retention_period"), null);
     }
 
     @Test
-    public void testPrepareUploadForCSV() throws NotificationClientException {
+    public void testPrepareUploadWithFilename() throws NotificationClientException {
         byte[] documentContent = "this is a document to test with".getBytes();
-        JSONObject response = NotificationClient.prepareUpload(documentContent, true);
+        JSONObject response = NotificationClient.prepareUpload(documentContent, "report.csv");
         JSONObject expectedResult = new JSONObject();
         expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
-        expectedResult.put("is_csv", true);
+        expectedResult.put("filename", "report.csv");
         expectedResult.put("confirm_email_before_download", JSONObject.NULL);
         expectedResult.put("retention_period", JSONObject.NULL);
         assertEquals(expectedResult.getString("file"), response.getString("file"));
-        assertEquals(expectedResult.getBoolean("is_csv"), response.getBoolean("is_csv"));
+        assertEquals(expectedResult.getString("filename"), response.getString("filename"));
+        assertEquals(response.optJSONObject("confirm_email_before_download"), null);
+        assertEquals(response.optJSONObject("retention_period"), null);
     }
 
     @Test
@@ -125,21 +129,40 @@ public class NotificationClientTest {
         byte[] documentContent = "this is a document to test with".getBytes();
         JSONObject response = NotificationClient.prepareUpload(
                 documentContent,
+                "report.csv",
                 true,
-                true,
-                "1 weeks"
-        );
+                "1 weeks");
         JSONObject expectedResult = new JSONObject();
         expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
-        expectedResult.put("is_csv", true);
+        expectedResult.put("filename", "report.csv");
         expectedResult.put("confirm_email_before_download", true);
         expectedResult.put("retention_period", "1 weeks");
         assertEquals(expectedResult.getString("file"), response.getString("file"));
-        assertEquals(expectedResult.getBoolean("is_csv"), response.getBoolean("is_csv"));
+        assertEquals(expectedResult.getString("filename"), response.getString("filename"));
         assertEquals(
                 expectedResult.getBoolean("confirm_email_before_download"),
-                response.getBoolean("confirm_email_before_download")
-        );
+                response.getBoolean("confirm_email_before_download"));
+        assertEquals(expectedResult.getString("retention_period"), response.getString("retention_period"));
+    }
+
+    @Test
+    public void testPrepareUploadWithFilenameAndEmailConfirmationAndRetentionPeriodDuration() throws NotificationClientException {
+        byte[] documentContent = "this is a document to test with".getBytes();
+        JSONObject response = NotificationClient.prepareUpload(
+                documentContent,
+                "report.csv",
+                true,
+                new RetentionPeriodDuration(1, ChronoUnit.WEEKS));
+        JSONObject expectedResult = new JSONObject();
+        expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
+        expectedResult.put("filename", "report.csv");
+        expectedResult.put("confirm_email_before_download", true);
+        expectedResult.put("retention_period", "1 weeks");
+        assertEquals(expectedResult.getString("file"), response.getString("file"));
+        assertEquals(expectedResult.getString("filename"), response.getString("filename"));
+        assertEquals(
+                expectedResult.getBoolean("confirm_email_before_download"),
+                response.getBoolean("confirm_email_before_download"));
         assertEquals(expectedResult.getString("retention_period"), response.getString("retention_period"));
     }
 
@@ -149,20 +172,17 @@ public class NotificationClientTest {
         JSONObject response = NotificationClient.prepareUpload(
                 documentContent,
                 true,
-                true,
-                new RetentionPeriodDuration(1, ChronoUnit.WEEKS)
-        );
+                new RetentionPeriodDuration(1, ChronoUnit.WEEKS));
         JSONObject expectedResult = new JSONObject();
         expectedResult.put("file", new String(Base64.encodeBase64(documentContent), ISO_8859_1));
-        expectedResult.put("is_csv", true);
+        expectedResult.put("filename", JSONObject.NULL);
         expectedResult.put("confirm_email_before_download", true);
         expectedResult.put("retention_period", "1 weeks");
         assertEquals(expectedResult.getString("file"), response.getString("file"));
-        assertEquals(expectedResult.getBoolean("is_csv"), response.getBoolean("is_csv"));
+        assertEquals(expectedResult.optJSONObject("filename"), null);
         assertEquals(
                 expectedResult.getBoolean("confirm_email_before_download"),
-                response.getBoolean("confirm_email_before_download")
-        );
+                response.getBoolean("confirm_email_before_download"));
         assertEquals(expectedResult.getString("retention_period"), response.getString("retention_period"));
     }
 


### PR DESCRIPTION
Update client for the new document download feature which allows
specifying a download filename for files sent by email.

This supercedes the old isCsv parameter that was inconsistent at best.

Given this, we are dropping support for `isCsv` altogether.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENTATION.md`)
- [x] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `pom.xml`
