### PR TITLE
Where UUIDs are expected change the type from String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Next release
+* Where UUIDs are expected the types in the API have changed from String to UUID.  You can wrap strings in UUID.fromString() if necessary.
+
 ## 5.1.0-RELEASE
 * Add a `oneClickUnsubscribeURL` parameter to `sendEmail`. The unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.  See https://www.notifications.service.gov.uk/using-notify/unsubscribe-links
 

--- a/src/main/java/uk/gov/service/notify/NotificationClient.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClient.java
@@ -23,6 +23,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -134,28 +135,28 @@ public class NotificationClient implements NotificationClientApi {
         return proxy;
     }
 
-    public SendEmailResponse sendEmail(String templateId,
+    public SendEmailResponse sendEmail(UUID templateId,
                                        String emailAddress,
                                        Map<String, ?> personalisation,
                                        String reference) throws NotificationClientException {
-        return sendEmail(templateId, emailAddress, personalisation, reference, "", null);
+        return sendEmail(templateId, emailAddress, personalisation, reference, null, null);
     }
 
     @Override
-    public SendEmailResponse sendEmail(String templateId,
+    public SendEmailResponse sendEmail(UUID templateId,
                                        String emailAddress,
                                        Map<String, ?> personalisation,
                                        String reference,
-                                       String emailReplyToId) throws NotificationClientException {
+                                       UUID emailReplyToId) throws NotificationClientException {
         return sendEmail(templateId, emailAddress, personalisation, reference, emailReplyToId, null);
     }
 
     @Override
-    public SendEmailResponse sendEmail(String templateId,
+    public SendEmailResponse sendEmail(UUID templateId,
                                        String emailAddress,
                                        Map<String, ?> personalisation,
                                        String reference,
-                                       String emailReplyToId,
+                                       UUID emailReplyToId,
                                        URI oneClickUnsubscribeURL) throws NotificationClientException {
 
         JSONObject body = createBodyForPostRequest(templateId,
@@ -166,7 +167,7 @@ public class NotificationClient implements NotificationClientApi {
                 null,
                 null);
 
-        if(emailReplyToId != null && !emailReplyToId.isEmpty())
+        if(emailReplyToId != null)
         {
             body.put("email_reply_to_id", emailReplyToId);
         }
@@ -181,15 +182,15 @@ public class NotificationClient implements NotificationClientApi {
         return new SendEmailResponse(response);
     }
 
-    public SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, ?> personalisation, String reference) throws NotificationClientException {
-        return sendSms(templateId, phoneNumber, personalisation, reference, "");
+    public SendSmsResponse sendSms(UUID templateId, String phoneNumber, Map<String, ?> personalisation, String reference) throws NotificationClientException {
+        return sendSms(templateId, phoneNumber, personalisation, reference, null);
     }
 
-    public SendSmsResponse sendSms(String templateId,
+    public SendSmsResponse sendSms(UUID templateId,
                                    String phoneNumber,
                                    Map<String, ?> personalisation,
                                    String reference,
-                                   String smsSenderId) throws NotificationClientException {
+                                   UUID smsSenderId) throws NotificationClientException {
 
         JSONObject body = createBodyForPostRequest(templateId,
                 phoneNumber,
@@ -199,7 +200,7 @@ public class NotificationClient implements NotificationClientApi {
                 null,
                 null);
 
-        if( smsSenderId != null && !smsSenderId.isEmpty()){
+        if( smsSenderId != null){
             body.put("sms_sender_id", smsSenderId);
         }
         HttpURLConnection conn = createConnectionAndSetHeaders(baseUrl + "/v2/notifications/sms", "POST");
@@ -207,14 +208,14 @@ public class NotificationClient implements NotificationClientApi {
         return new SendSmsResponse(response);
     }
 
-    public SendLetterResponse sendLetter(String templateId, Map<String, ?> personalisation, String reference) throws NotificationClientException {
+    public SendLetterResponse sendLetter(UUID templateId, Map<String, ?> personalisation, String reference) throws NotificationClientException {
         JSONObject body = createBodyForPostRequest(templateId, null, null, personalisation, reference, null, null);
         HttpURLConnection conn = createConnectionAndSetHeaders(baseUrl + "/v2/notifications/letter", "POST");
         String response = performPostRequest(conn, body, HttpsURLConnection.HTTP_CREATED);
         return new SendLetterResponse(response);
     }
 
-    public Notification getNotificationById(String notificationId) throws NotificationClientException {
+    public Notification getNotificationById(UUID notificationId) throws NotificationClientException {
         String url = baseUrl + "/v2/notifications/" + notificationId;
         HttpURLConnection conn = createConnectionAndSetHeaders(url, "GET");
         String response = performGetRequest(conn);
@@ -222,14 +223,14 @@ public class NotificationClient implements NotificationClientApi {
 
     }
 
-    public byte[] getPdfForLetter(String notificationId) throws NotificationClientException {
+    public byte[] getPdfForLetter(UUID notificationId) throws NotificationClientException {
         String url = baseUrl + "/v2/notifications/" + notificationId + "/pdf";
         HttpURLConnection conn = createConnectionAndSetHeaders(url, "GET");
 
         return performRawGetRequest(conn);
     }
 
-    public NotificationList getNotifications(String status, String notification_type, String reference, String olderThanId) throws NotificationClientException {
+    public NotificationList getNotifications(String status, String notification_type, String reference, UUID olderThanId) throws NotificationClientException {
         try {
             URIBuilder builder = new URIBuilder(baseUrl + "/v2/notifications");
             if (status != null && !status.isEmpty()) {
@@ -241,8 +242,8 @@ public class NotificationClient implements NotificationClientApi {
             if (reference != null && !reference.isEmpty()) {
                 builder.addParameter("reference", reference);
             }
-            if (olderThanId != null && !olderThanId.isEmpty()) {
-                builder.addParameter("older_than", olderThanId);
+            if (olderThanId != null) {
+                builder.addParameter("older_than", olderThanId.toString());
             }
 
             HttpURLConnection conn = createConnectionAndSetHeaders(builder.toString(), "GET");
@@ -254,14 +255,14 @@ public class NotificationClient implements NotificationClientApi {
         }
     }
 
-    public Template getTemplateById(String templateId) throws NotificationClientException{
+    public Template getTemplateById(UUID templateId) throws NotificationClientException{
         String url = baseUrl + "/v2/template/" + templateId;
         HttpURLConnection conn = createConnectionAndSetHeaders(url, "GET");
         String response = performGetRequest(conn);
         return new Template(response);
     }
 
-    public Template getTemplateVersion(String templateId, int version) throws NotificationClientException{
+    public Template getTemplateVersion(UUID templateId, int version) throws NotificationClientException{
         String url = baseUrl + "/v2/template/" + templateId + "/version/" + version;
         HttpURLConnection conn = createConnectionAndSetHeaders(url, "GET");
         String response = performGetRequest(conn);
@@ -283,7 +284,7 @@ public class NotificationClient implements NotificationClientApi {
         }
     }
 
-    public TemplatePreview generateTemplatePreview(String templateId, Map<String, Object> personalisation) throws NotificationClientException {
+    public TemplatePreview generateTemplatePreview(UUID templateId, Map<String, Object> personalisation) throws NotificationClientException {
         JSONObject body = new JSONObject();
         if (personalisation != null && !personalisation.isEmpty()) {
             body.put("personalisation", new JSONObject(personalisation));
@@ -293,11 +294,11 @@ public class NotificationClient implements NotificationClientApi {
         return new TemplatePreview(response);
     }
 
-    public ReceivedTextMessageList getReceivedTextMessages(String olderThanId) throws NotificationClientException {
+    public ReceivedTextMessageList getReceivedTextMessages(UUID olderThanId) throws NotificationClientException {
         try {
             URIBuilder builder = new URIBuilder(baseUrl + "/v2/received-text-messages");
-            if (olderThanId != null && !olderThanId.isEmpty()) {
-                builder.addParameter("older_than", olderThanId);
+            if (olderThanId != null) {
+                builder.addParameter("older_than", olderThanId.toString());
             }
             HttpURLConnection conn = createConnectionAndSetHeaders(builder.toString(), "GET");
             String response = performGetRequest(conn);
@@ -548,7 +549,7 @@ public class NotificationClient implements NotificationClientApi {
         return conn;
     }
 
-    private JSONObject createBodyForPostRequest(final String templateId,
+    private JSONObject createBodyForPostRequest(final UUID templateId,
                                                 final String phoneNumber,
                                                 final String emailAddress,
                                                 final Map<String, ?> personalisation,
@@ -565,7 +566,7 @@ public class NotificationClient implements NotificationClientApi {
             body.put("email_address", emailAddress);
         }
 
-        if(templateId != null && !templateId.isEmpty()) {
+        if(templateId != null) {
             body.put("template_id", templateId);
         }
 

--- a/src/main/java/uk/gov/service/notify/NotificationClientApi.java
+++ b/src/main/java/uk/gov/service/notify/NotificationClientApi.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
+import java.util.UUID;
 
 public interface NotificationClientApi {
 
@@ -21,7 +22,7 @@ public interface NotificationClientApi {
      * @return <code>SendEmailResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#send-an-email-error-codes
      */
-    SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, ?> personalisation, String reference) throws NotificationClientException;
+    SendEmailResponse sendEmail(UUID templateId, String emailAddress, Map<String, ?> personalisation, String reference) throws NotificationClientException;
 
 
     /**
@@ -40,7 +41,7 @@ public interface NotificationClientApi {
      * @return <code>SendEmailResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#send-an-email-error-codes
      */
-    SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, ?> personalisation, String reference, String emailReplyToId) throws NotificationClientException;
+    SendEmailResponse sendEmail(UUID templateId, String emailAddress, Map<String, ?> personalisation, String reference, UUID emailReplyToId) throws NotificationClientException;
 
     /**
      * The sendEmail method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
@@ -59,7 +60,7 @@ public interface NotificationClientApi {
      * @return <code>SendEmailResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#send-an-email-error-codes
      */
-    SendEmailResponse sendEmail(String templateId, String emailAddress, Map<String, ?> personalisation, String reference, String emailReplyToId, URI oneClickUnsubscribeURL) throws NotificationClientException;
+    SendEmailResponse sendEmail(UUID templateId, String emailAddress, Map<String, ?> personalisation, String reference, UUID emailReplyToId, URI oneClickUnsubscribeURL) throws NotificationClientException;
 
     /**
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
@@ -74,7 +75,7 @@ public interface NotificationClientApi {
      * @return <code>SendSmsResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#error-codes
      */
-    SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, ?> personalisation, String reference) throws NotificationClientException;
+    SendSmsResponse sendSms(UUID templateId, String phoneNumber, Map<String, ?> personalisation, String reference) throws NotificationClientException;
 
     /**
      * The sendSms method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
@@ -92,7 +93,7 @@ public interface NotificationClientApi {
      * @return <code>SendSmsResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#error-codes
      */
-    SendSmsResponse sendSms(String templateId, String phoneNumber, Map<String, ?> personalisation, String reference, String smsSenderId) throws NotificationClientException;
+    SendSmsResponse sendSms(UUID templateId, String phoneNumber, Map<String, ?> personalisation, String reference, UUID smsSenderId) throws NotificationClientException;
 
     /**
      * The sendLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
@@ -106,7 +107,7 @@ public interface NotificationClientApi {
      * @return <code>SendLetterResponse</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#send-a-letter-error-codes
      */
-    SendLetterResponse sendLetter(String templateId, Map<String, ?> personalisation, String reference) throws NotificationClientException;
+    SendLetterResponse sendLetter(UUID templateId, Map<String, ?> personalisation, String reference) throws NotificationClientException;
 
     /**
      * The sendPrecompiledLetter method will create an HTTPS POST request. A JWT token will be created and added as an Authorization header to the request.
@@ -177,7 +178,7 @@ public interface NotificationClientApi {
      * @return <code>Notification</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#get-the-status-of-one-message-error-codes
      */
-    Notification getNotificationById(String notificationId) throws NotificationClientException;
+    Notification getNotificationById(UUID notificationId) throws NotificationClientException;
 
     /**
      * The getPdfForLetter method will return a <code>byte[]</code> containing the PDF contents of a given letter notification.
@@ -187,7 +188,7 @@ public interface NotificationClientApi {
      * @return <code>byte[]</code> The raw pdf data.
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#get-a-pdf-for-a-letter-notification-error-codes
      */
-    byte[] getPdfForLetter(String notificationId) throws NotificationClientException;
+    byte[] getPdfForLetter(UUID notificationId) throws NotificationClientException;
 
     /**
      * The getNotifications method will create a GET HTTPS request to retrieve all the notifications.
@@ -197,11 +198,11 @@ public interface NotificationClientApi {
      * @param notification_type If notification_type is not empty or null only notifications of the given status will be returned.
      *                          Possible notificationTypes are sms|email
      * @param reference If reference is not empty or null only the notifications with that reference are returned.
-     * @param olderThanId If olderThanId is not empty or null only the notifications older than that notification id are returned.
+     * @param olderThanId If olderThanId is not null only the notifications older than that notification id are returned.
      * @return <code>NotificationList</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#get-the-status-of-multiple-messages-error-codes
      */
-    NotificationList getNotifications(String status, String notification_type, String reference, String olderThanId) throws NotificationClientException;
+    NotificationList getNotifications(String status, String notification_type, String reference, UUID olderThanId) throws NotificationClientException;
 
     /**
      * The getTemplateById returns a <code>Template</code> given the template id.
@@ -210,7 +211,7 @@ public interface NotificationClientApi {
      * @return <code>Template</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#get-a-template-by-id-error-codes
      */
-    Template getTemplateById(String templateId) throws NotificationClientException;
+    Template getTemplateById(UUID templateId) throws NotificationClientException;
 
     /**
      * The getTemplateVersion returns a <code>Template</code> given the template id and version.
@@ -220,7 +221,7 @@ public interface NotificationClientApi {
      * @return <code>Template</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#get-a-template-by-id-and-version-error-codes
      */
-    Template getTemplateVersion(String templateId, int version) throws NotificationClientException;
+    Template getTemplateVersion(UUID templateId, int version) throws NotificationClientException;
 
     /**
      * Returns all the templates for your service. Filtered by template type if not null.
@@ -241,7 +242,7 @@ public interface NotificationClientApi {
      * @return <code>Template</code>
      * @throws NotificationClientException see https://docs.notifications.service.gov.uk/java.html#generate-a-preview-template-error-codes
      */
-    TemplatePreview generateTemplatePreview(String templateId, Map<String, Object> personalisation) throws NotificationClientException;
+    TemplatePreview generateTemplatePreview(UUID templateId, Map<String, Object> personalisation) throws NotificationClientException;
 
     /**
      * The getReceivedTextMessages returns a list of <code>ReceivedTextMessage</code>, the list is sorted by createdAt descending.
@@ -249,5 +250,5 @@ public interface NotificationClientApi {
      * @return <code>ReceivedTextMessageList</code>
      * @throws NotificationClientException
      */
-    ReceivedTextMessageList getReceivedTextMessages(String olderThanId) throws NotificationClientException;
+    ReceivedTextMessageList getReceivedTextMessages(UUID olderThanId) throws NotificationClientException;
 }

--- a/src/test/java/uk/gov/service/notify/NotificationClientTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationClientTest.java
@@ -296,9 +296,10 @@ public class NotificationClientTest {
         wireMockRule.stubFor(post("/v2/notifications/sms")
                 .willReturn(notFound()));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
+        UUID templateId = UUID.randomUUID();
 
         NotificationClientException e = assertThrows(NotificationClientException.class,
-                () -> client.sendSms("aTemplateId", "aPhoneNumber", emptyMap(), "aReference"));
+                () -> client.sendSms(templateId, "aPhoneNumber", emptyMap(), "aReference"));
 
         assertEquals(404, e.getHttpResult());
         assertEquals("Status code: 404 ", e.getMessage());
@@ -311,9 +312,11 @@ public class NotificationClientTest {
         wireMockRule.stubFor(post("/v2/notifications/email")
                 .willReturn(serverError()));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
+        UUID templateId = UUID.randomUUID();
+        UUID emailReplyToId = UUID.randomUUID();
 
         NotificationClientException e = assertThrows(NotificationClientException.class,
-                () -> client.sendEmail("aTemplateId", "anEmailAddress", emptyMap(), "aReference", "an emailReplyToId"));
+                () -> client.sendEmail(templateId, "anEmailAddress", emptyMap(), "aReference", emailReplyToId));
 
         assertEquals(500, e.getHttpResult());
         assertEquals("Status code: 500 ", e.getMessage());
@@ -331,8 +334,10 @@ public class NotificationClientTest {
         // setting up this map can be replaced with Map.of() in later Java versions
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("application_date", "2018-01-01");
+        UUID templateId = UUID.randomUUID();
+        UUID emailReplyToId = UUID.randomUUID();
 
-        SendEmailResponse actual = client.sendEmail("aTemplateId", "anEmailAddress", personalisation, "aReference", "an emailReplyToId");
+        SendEmailResponse actual = client.sendEmail(templateId, "anEmailAddress", personalisation, "aReference", emailReplyToId);
 
         assertEquals(expected.getNotificationId(), actual.getNotificationId());
         assertEquals(expected.getReference(), actual.getReference().get());
@@ -349,10 +354,10 @@ public class NotificationClientTest {
         LoggedRequest request = validateRequest();
         NotifyEmailRequest requestReceivedByNotifyApi = objectMapper.readValue(request.getBodyAsString(), NotifyEmailRequest.class);
         assertEquals("anEmailAddress", requestReceivedByNotifyApi.getEmailAddress());
-        assertEquals("aTemplateId", requestReceivedByNotifyApi.getTemplateId());
+        assertEquals(templateId, requestReceivedByNotifyApi.getTemplateId());
         assertEquals(personalisation, requestReceivedByNotifyApi.getPersonalisation());
         assertEquals("aReference", requestReceivedByNotifyApi.getReference());
-        assertEquals("an emailReplyToId", requestReceivedByNotifyApi.getEmailReplyToId());
+        assertEquals(emailReplyToId, requestReceivedByNotifyApi.getEmailReplyToId());
         assertNull(requestReceivedByNotifyApi.getOneClickUnsubscribeURL());
     }
 
@@ -367,8 +372,10 @@ public class NotificationClientTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("application_date", "2018-01-01");
         URI oneClickUnsubscribeURL = URI.create("http://localhost/unsubscribe");
+        UUID templateId = UUID.randomUUID();
+        UUID emailReplyToId = UUID.randomUUID();
 
-        SendEmailResponse actual = client.sendEmail("aTemplateId", "anEmailAddress", personalisation, "aReference", "an emailReplyToId", oneClickUnsubscribeURL);
+        SendEmailResponse actual = client.sendEmail(templateId, "anEmailAddress", personalisation, "aReference", emailReplyToId, oneClickUnsubscribeURL);
 
         assertEquals(expected.getNotificationId(), actual.getNotificationId());
         assertEquals(expected.getReference(), actual.getReference().get());
@@ -385,10 +392,10 @@ public class NotificationClientTest {
         LoggedRequest request = validateRequest();
         NotifyEmailRequest requestReceivedByNotifyApi = objectMapper.readValue(request.getBodyAsString(), NotifyEmailRequest.class);
         assertEquals("anEmailAddress", requestReceivedByNotifyApi.getEmailAddress());
-        assertEquals("aTemplateId", requestReceivedByNotifyApi.getTemplateId());
+        assertEquals(templateId, requestReceivedByNotifyApi.getTemplateId());
         assertEquals(personalisation, requestReceivedByNotifyApi.getPersonalisation());
         assertEquals("aReference", requestReceivedByNotifyApi.getReference());
-        assertEquals("an emailReplyToId", requestReceivedByNotifyApi.getEmailReplyToId());
+        assertEquals(emailReplyToId, requestReceivedByNotifyApi.getEmailReplyToId());
         assertEquals(oneClickUnsubscribeURL, requestReceivedByNotifyApi.getOneClickUnsubscribeURL());
     }
 
@@ -397,9 +404,11 @@ public class NotificationClientTest {
         wireMockRule.stubFor(post("/v2/notifications/sms")
                 .willReturn(serverError()));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
+        UUID templateId = UUID.randomUUID();
+        UUID smsSenderId = UUID.randomUUID();
 
         NotificationClientException e = assertThrows(NotificationClientException.class,
-                () -> client.sendSms("aTemplateId", "a phone number", emptyMap(), "aReference", "an smsSenderId"));
+                () -> client.sendSms(templateId, "a phone number", emptyMap(), "aReference", smsSenderId));
 
         assertEquals(500, e.getHttpResult());
         assertEquals("Status code: 500 ", e.getMessage());
@@ -417,8 +426,10 @@ public class NotificationClientTest {
         // setting up this map can be replaced with Map.of() in later Java versions
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("application_date", "2018-01-01");
+        UUID templateId = UUID.randomUUID();
+        UUID smsSenderId = UUID.randomUUID();
 
-        SendSmsResponse actual = client.sendSms("aTemplateId", "a phone number", personalisation, "aReference", "an smsSenderId");
+        SendSmsResponse actual = client.sendSms(templateId, "a phone number", personalisation, "aReference", smsSenderId);
 
         assertEquals(expected.getNotificationId(), actual.getNotificationId());
         assertEquals(expected.getReference(), actual.getReference().get());
@@ -433,10 +444,10 @@ public class NotificationClientTest {
         LoggedRequest request = validateRequest();
         NotifySmsRequest requestReceivedByNotifyApi = objectMapper.readValue(request.getBodyAsString(), NotifySmsRequest.class);
         assertEquals("a phone number", requestReceivedByNotifyApi.getPhoneNumber());
-        assertEquals("aTemplateId", requestReceivedByNotifyApi.getTemplateId());
+        assertEquals(templateId, requestReceivedByNotifyApi.getTemplateId());
         assertEquals(personalisation, requestReceivedByNotifyApi.getPersonalisation());
         assertEquals("aReference", requestReceivedByNotifyApi.getReference());
-        assertEquals("an smsSenderId", requestReceivedByNotifyApi.getSmsSenderId());
+        assertEquals(smsSenderId, requestReceivedByNotifyApi.getSmsSenderId());
     }
 
     @Test
@@ -449,9 +460,10 @@ public class NotificationClientTest {
         personalisation.put("address_line_1", "a1");
         personalisation.put("address_line_2", "a2");
         personalisation.put("address_line_3", "a3");
+        UUID templateId = UUID.randomUUID();
 
         NotificationClientException e = assertThrows(NotificationClientException.class,
-                () -> client.sendLetter("aTemplateId", personalisation, "aReference"));
+                () -> client.sendLetter(templateId, personalisation, "aReference"));
 
         assertEquals(500, e.getHttpResult());
         assertEquals("Status code: 500 ", e.getMessage());
@@ -471,8 +483,9 @@ public class NotificationClientTest {
         personalisation.put("address_line_1", "a1");
         personalisation.put("address_line_2", "a2");
         personalisation.put("address_line_3", "a3");
+        UUID templateId = UUID.randomUUID();
 
-        SendLetterResponse actual = client.sendLetter("aTemplateId", personalisation, "aReference");
+        SendLetterResponse actual = client.sendLetter(templateId, personalisation, "aReference");
 
         assertEquals(expected.getNotificationId(), actual.getNotificationId());
         assertEquals(expected.getReference(), actual.getReference().get());
@@ -488,7 +501,7 @@ public class NotificationClientTest {
 
         LoggedRequest request = validateRequest();
         NotifyLetterRequest requestReceivedByNotifyApi = objectMapper.readValue(request.getBodyAsString(), NotifyLetterRequest.class);
-        assertEquals("aTemplateId", requestReceivedByNotifyApi.getTemplateId());
+        assertEquals(templateId, requestReceivedByNotifyApi.getTemplateId());
         assertEquals(personalisation, requestReceivedByNotifyApi.getPersonalisation());
         assertEquals("aReference", requestReceivedByNotifyApi.getReference());
     }
@@ -502,7 +515,7 @@ public class NotificationClientTest {
                         .withResponseBody(new Body(objectMapper.writeValueAsString(expected)))));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
 
-        Notification actual = client.getNotificationById(notificationId.toString());
+        Notification actual = client.getNotificationById(notificationId);
 
         assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.getReference(), actual.getReference().get());
@@ -539,8 +552,9 @@ public class NotificationClientTest {
                 .willReturn(ok()
                         .withResponseBody(new Body(objectMapper.writeValueAsString(expected)))));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
+        UUID olderThanId = UUID.randomUUID();
 
-        NotificationList actual = client.getNotifications("a stat", "a notification_type", "a ref", "an olderThanId");
+        NotificationList actual = client.getNotifications("a stat", "a notification_type", "a ref", olderThanId);
 
         assertEquals(expected.getNotifications().size(), actual.getNotifications().size());
         assertEquals(expected.getLinks().getCurrent().toString(), actual.getCurrentPageLink());
@@ -575,7 +589,7 @@ public class NotificationClientTest {
         assertEquals("a stat", request.queryParameter("status").firstValue());
         assertEquals("a notification_type", request.queryParameter("template_type").firstValue());
         assertEquals("a ref", request.queryParameter("reference").firstValue());
-        assertEquals("an olderThanId", request.queryParameter("older_than").firstValue());
+        assertEquals(olderThanId.toString(), request.queryParameter("older_than").firstValue());
     }
 
     @Test
@@ -587,7 +601,7 @@ public class NotificationClientTest {
                         .withResponseBody(new Body(pdfFile))));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
 
-        byte[] responsePdf = client.getPdfForLetter(notificationId.toString());
+        byte[] responsePdf = client.getPdfForLetter(notificationId);
 
         assertArrayEquals(pdfFile, responsePdf);
 
@@ -626,7 +640,7 @@ public class NotificationClientTest {
                         .withResponseBody(new Body(objectMapper.writeValueAsString(expected)))));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
 
-        Template actual = client.getTemplateById(templateId.toString());
+        Template actual = client.getTemplateById(templateId);
 
         assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.getName(), actual.getName());
@@ -653,7 +667,7 @@ public class NotificationClientTest {
                         .withResponseBody(new Body(objectMapper.writeValueAsString(expected)))));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
 
-        Template actual = client.getTemplateVersion(templateId.toString(), 100);
+        Template actual = client.getTemplateVersion(templateId, 100);
 
         assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.getName(), actual.getName());
@@ -711,7 +725,7 @@ public class NotificationClientTest {
                         .withResponseBody(new Body(objectMapper.writeValueAsString(expected)))));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
 
-        TemplatePreview actual = client.generateTemplatePreview(templateId.toString(), personalisation);
+        TemplatePreview actual = client.generateTemplatePreview(templateId, personalisation);
 
         assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.getType(), actual.getTemplateType());
@@ -731,8 +745,9 @@ public class NotificationClientTest {
                 .willReturn(ok()
                         .withResponseBody(new Body(objectMapper.writeValueAsString(expected)))));
         NotificationClient client = new NotificationClient(COMBINED_API_KEY, BASE_URL);
+        UUID olderThanId = UUID.randomUUID();
 
-        ReceivedTextMessageList actual = client.getReceivedTextMessages("2024-05-13");
+        ReceivedTextMessageList actual = client.getReceivedTextMessages(olderThanId);
 
         assertEquals(expected.getReceivedTextMessages().size(), actual.getReceivedTextMessages().size());
         assertEquals(expected.getReceivedTextMessages().get(0).getId(), actual.getReceivedTextMessages().get(0).getId());
@@ -746,7 +761,7 @@ public class NotificationClientTest {
         assertEquals(expected.getLinks().getNext().toString(), actual.getNextPageLink().get());
 
         LoggedRequest request = validateRequest();
-        assertEquals("2024-05-13", request.queryParameter("older_than").firstValue());
+        assertEquals(olderThanId.toString(), request.queryParameter("older_than").firstValue());
     }
 
     @Test
@@ -766,9 +781,10 @@ public class NotificationClientTest {
                 .willReturn(unauthorized()));
         final UUID badApiKey = UUID.randomUUID();
         NotificationClient client = new NotificationClient("Api_key_name-" + SERVICE_ID + "-" + badApiKey, BASE_URL);
+        UUID templateId = UUID.randomUUID();
 
         NotificationClientException e = assertThrows(NotificationClientException.class,
-                () -> client.sendSms("aTemplateId", "aPhoneNumber", emptyMap(), "aReference"));
+                () -> client.sendSms(templateId, "aPhoneNumber", emptyMap(), "aReference"));
 
         assertEquals(401, e.getHttpResult());
         assertEquals("Status code: 401 ", e.getMessage());

--- a/src/test/java/uk/gov/service/notify/domain/NotifyEmailRequest.java
+++ b/src/test/java/uk/gov/service/notify/domain/NotifyEmailRequest.java
@@ -5,21 +5,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 public class NotifyEmailRequest {
 
     private final String emailAddress;
-    private final String templateId;
+    private final UUID templateId;
     private final Map<String, ?> personalisation;
     private final String reference;
-    private final String emailReplyToId;
+    private final UUID emailReplyToId;
     private final URI oneClickUnsubscribeURL;
 
     public NotifyEmailRequest(@JsonProperty("email_address") String emailAddress,
-                              @JsonProperty("template_id") String templateId,
+                              @JsonProperty("template_id") UUID templateId,
                               @JsonProperty("personalisation") Map<String, ?> personalisation,
                               @JsonProperty("reference") String reference,
-                              @JsonProperty("email_reply_to_id") String emailReplyToId,
+                              @JsonProperty("email_reply_to_id") UUID emailReplyToId,
                               @JsonProperty("one_click_unsubscribe_url") URI oneClickUnsubscribeURL) {
         this.emailAddress = emailAddress;
         this.templateId = templateId;
@@ -35,7 +36,7 @@ public class NotifyEmailRequest {
     }
 
     @JsonProperty("template_id")
-    public String getTemplateId() {
+    public UUID getTemplateId() {
         return templateId;
     }
 
@@ -50,7 +51,7 @@ public class NotifyEmailRequest {
     }
 
     @JsonProperty("email_reply_to_id")
-    public String getEmailReplyToId() {
+    public UUID getEmailReplyToId() {
         return emailReplyToId;
     }
 

--- a/src/test/java/uk/gov/service/notify/domain/NotifyLetterRequest.java
+++ b/src/test/java/uk/gov/service/notify/domain/NotifyLetterRequest.java
@@ -7,14 +7,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 public class NotifyLetterRequest {
 
-    private final String templateId;
+    private final UUID templateId;
     private final Map<String, ?> personalisation;
     private final String reference;
 
-    public NotifyLetterRequest(@JsonProperty("template_id") String templateId,
+    public NotifyLetterRequest(@JsonProperty("template_id") UUID templateId,
                                @JsonProperty("personalisation") Map<String, ?> personalisation,
                                @JsonProperty("reference") String reference) throws NotificationClientException {
         this.templateId = templateId;
@@ -32,7 +33,7 @@ public class NotifyLetterRequest {
     }
 
     @JsonProperty("template_id")
-    public String getTemplateId() {
+    public UUID getTemplateId() {
         return templateId;
     }
 

--- a/src/test/java/uk/gov/service/notify/domain/NotifySmsRequest.java
+++ b/src/test/java/uk/gov/service/notify/domain/NotifySmsRequest.java
@@ -4,19 +4,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 public class NotifySmsRequest {
     private final String phoneNumber;
-    private final String templateId;
+    private final UUID templateId;
     private final Map<String, ?> personalisation;
     private final String reference;
-    private final String smsSenderId;
+    private final UUID smsSenderId;
 
     public NotifySmsRequest(@JsonProperty("phone_number") String phoneNumber,
-                            @JsonProperty("template_id") String templateId,
+                            @JsonProperty("template_id") UUID templateId,
                             @JsonProperty("personalisation") Map<String, ?> personalisation,
                             @JsonProperty("reference") String reference,
-                            @JsonProperty("sms_sender_id") String smsSenderId) {
+                            @JsonProperty("sms_sender_id") UUID smsSenderId) {
         this.phoneNumber = phoneNumber;
         this.templateId = templateId;
         this.personalisation = personalisation;
@@ -30,7 +31,7 @@ public class NotifySmsRequest {
     }
 
     @JsonProperty("temnplate_id")
-    public String getTemplateId() {
+    public UUID getTemplateId() {
         return templateId;
     }
 
@@ -45,7 +46,7 @@ public class NotifySmsRequest {
     }
 
     @JsonProperty("sms_sender_id")
-    public String getSmsSenderId() {
+    public UUID getSmsSenderId() {
         return smsSenderId;
     }
 


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Changes the external API to ensure that UUID are passed instead of a String

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_java.md)
  - [x] `CHANGELOG.md`
- [ ] I’ve bumped the version number
    - [ ] in `src/main/resources/application.properties`
    - [ ] in `pom.xml`
