### PR TITLE
chore: add new fields to notification class (cost_in_pounds, is_data_ready and cost_details)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 5.2.0-RELEASE
+* Added fields related to cost data in response:
+  * `is_cost_data_ready`: This field is true if cost data is ready, and false if it isn't (Boolean).
+  * `cost_in_pounds`: Cost of the notification in pounds. The cost does not take free allowance into account (Float).
+  * `cost_details.billable_sms_fragments`: Number of billable SMS fragments in your text message (SMS only) (Integer).
+  * `cost_details.international_rate_multiplier`: For international SMS rate is multiplied by this value (SMS only) (Integer).
+  * `cost_details.sms_rate`: Cost of 1 SMS fragment (SMS only) (Float).
+  * `cost_details.billable_sheets_of_paper`: Number of sheets of paper in the letter you sent, that you will be charged for (letter only) (Integer).
+  * `cost_details.postage`: Postage class of the notification sent (letter only) (String).
+
 ## 5.1.0-RELEASE
 * Add a `oneClickUnsubscribeURL` parameter to `sendEmail`. The unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.  See https://www.notifications.service.gov.uk/using-notify/unsubscribe-links
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>5.1.0-RELEASE</version>
+    <version>5.2.0-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>GOV.UK Notify Java client</name>

--- a/src/main/java/uk/gov/service/notify/CostDetails.java
+++ b/src/main/java/uk/gov/service/notify/CostDetails.java
@@ -1,0 +1,81 @@
+package uk.gov.service.notify;
+
+import org.json.JSONObject;
+
+import java.util.Optional;
+
+public class CostDetails {
+    private Integer billableSmsFragments;
+    private Double internationalRateMultiplier;
+    private Double smsRate;
+    private Integer billableSheetsOfPaper;
+    private String postage;
+
+    public CostDetails(String content) {
+        JSONObject responseBodyAsJson = new JSONObject(content);
+        build(responseBodyAsJson);
+    }
+
+    public CostDetails(JSONObject data) {
+        build(data);
+    }
+
+    private void build(JSONObject data) {
+        billableSmsFragments = data.isNull("billable_sms_fragments") ? null : data.getInt("billable_sms_fragments");
+        internationalRateMultiplier = data.isNull("international_rate_multiplier") ? null : data.getDouble("international_rate_multiplier");
+        smsRate = data.isNull("sms_rate") ? null : data.getDouble("sms_rate");
+        billableSheetsOfPaper = data.isNull("billable_sheets_of_paper") ? null : data.getInt("billable_sheets_of_paper");
+        postage = data.isNull("postage") ? null : data.getString("postage");
+    }
+
+    public Optional<Integer> getBillableSmsFragments() {
+        return Optional.ofNullable(billableSmsFragments);
+    }
+
+    public void setBillableSmsFragments(Integer billableSmsFragments) {
+        this.billableSmsFragments = billableSmsFragments;
+    }
+
+    public Optional<Double> getInternationalRateMultiplier() {
+        return Optional.ofNullable(internationalRateMultiplier);
+    }
+
+    public void setInternationalRateMultiplier(Double internationalRateMultiplier) {
+        this.internationalRateMultiplier = internationalRateMultiplier;
+    }
+
+    public Optional<Double> getSmsRate() {
+        return Optional.ofNullable(smsRate);
+    }
+
+    public void setSmsRate(Double smsRate) {
+        this.smsRate = smsRate;
+    }
+
+    public Optional<Integer> getBillableSheetsOfPaper() {
+        return Optional.ofNullable(billableSheetsOfPaper);
+    }
+
+    public void setBillableSheetsOfPaper(Integer billableSheetsOfPaper) {
+        this.billableSheetsOfPaper = billableSheetsOfPaper;
+    }
+
+    public Optional<String> getPostage() {
+        return Optional.ofNullable(postage);
+    }
+
+    public void setPostage(String postage) {
+        this.postage = postage;
+    }
+
+    @Override
+    public String toString() {
+        return "CostDetails{" +
+                "billableSmsFragments=" + billableSmsFragments +
+                ", internationalRateMultiplier=" + internationalRateMultiplier +
+                ", smsRate=" + smsRate +
+                ", billableSheetsOfPaper=" + billableSheetsOfPaper +
+                ", postage='" + postage + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/service/notify/Notification.java
+++ b/src/main/java/uk/gov/service/notify/Notification.java
@@ -21,16 +21,29 @@ public class Notification {
     private String postage;
     private String notificationType;
     private String status;
-    private UUID templateId;
-    private int templateVersion;
-    private String templateUri;
     private String body;
     private String subject;
     private ZonedDateTime createdAt;
     private ZonedDateTime sentAt;
     private ZonedDateTime completedAt;
     private ZonedDateTime estimatedDelivery;
+//     private ZonedDateTime scheduledFor;
+//     private String oneClickUnsubscribe;
     private String createdByName;
+    private boolean isCostDataReady;
+    private double costInPounds;
+
+    // Template fields
+    private UUID templateId;
+    private int templateVersion;
+    private String templateUri;
+
+    // CostDetails fields
+    private Integer billableSmsFragments;
+    private Double internationalRateMultiplier;
+    private Double smsRate;
+    private Integer billableSheetsOfPaper;
+    private String costPostage;
 
     public Notification(String content){
         JSONObject responseBodyAsJson = new JSONObject(content);
@@ -67,6 +80,22 @@ public class Notification {
         completedAt = data.isNull("completed_at") ? null : ZonedDateTime.parse(data.getString("completed_at"));
         estimatedDelivery = data.isNull("estimated_delivery") ? null : ZonedDateTime.parse(data.getString("estimated_delivery"));
         createdByName = data.isNull("created_by_name") ? null : data.getString("created_by_name");
+
+        // Deconstructing CostDetails
+        if (!data.isNull("cost_details")) {
+            JSONObject costDetails = data.getJSONObject("cost_details");
+            billableSmsFragments = costDetails.isNull("billable_sms_fragments") ? null : costDetails.getInt("billable_sms_fragments");
+            internationalRateMultiplier = costDetails.isNull("international_rate_multiplier") ? null : costDetails.getDouble("international_rate_multiplier");
+            smsRate = costDetails.isNull("sms_rate") ? null : costDetails.getDouble("sms_rate");
+            billableSheetsOfPaper = costDetails.isNull("billable_sheets_of_paper") ? null : costDetails.getInt("billable_sheets_of_paper");
+            costPostage = costDetails.isNull("postage") ? null : costDetails.getString("postage");
+        } else {
+            billableSmsFragments = null;
+            internationalRateMultiplier = null;
+            smsRate = null;
+            billableSheetsOfPaper = null;
+            costPostage = null;
+        }
     }
 
     public UUID getId() {
@@ -112,6 +141,7 @@ public class Notification {
     public Optional<String> getPostcode() {
         return Optional.ofNullable(postcode);
     }
+
     public Optional<String> getPostage() {
         return Optional.ofNullable(postage);
     }
@@ -167,6 +197,35 @@ public class Notification {
         return Optional.ofNullable(estimatedDelivery);
     }
 
+    public boolean isCostDataReady() {
+            return isCostDataReady;
+        }
+
+    public double getCostInPounds() {
+        return costInPounds;
+    }
+
+    // Getters for CostDetails fields
+    public Optional<Integer> getBillableSmsFragments() {
+        return Optional.ofNullable(billableSmsFragments);
+    }
+
+    public Optional<Double> getInternationalRateMultiplier() {
+        return Optional.ofNullable(internationalRateMultiplier);
+    }
+
+    public Optional<Double> getSmsRate() {
+        return Optional.ofNullable(smsRate);
+    }
+
+    public Optional<Integer> getBillableSheetsOfPaper() {
+        return Optional.ofNullable(billableSheetsOfPaper);
+    }
+
+    public Optional<String> getCostPostage() {
+        return Optional.ofNullable(costPostage);
+    }
+
     @Override
     public String toString() {
         return "Notification{" +
@@ -193,6 +252,13 @@ public class Notification {
                 ", completedAt=" + completedAt +
                 ", estimatedDelivery=" + estimatedDelivery +
                 ", createdByName=" + createdByName +
+                ", isCostDataReady=" + isCostDataReady +
+                ", costInPounds=" + costInPounds +
+                ", billableSmsFragments=" + billableSmsFragments +
+                ", internationalRateMultiplier=" + internationalRateMultiplier +
+                ", smsRate=" + smsRate +
+                ", billableSheetsOfPaper=" + billableSheetsOfPaper +
+                ", costPostage='" + costPostage + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/service/notify/Notification.java
+++ b/src/main/java/uk/gov/service/notify/Notification.java
@@ -43,7 +43,7 @@ public class Notification {
     private Double internationalRateMultiplier;
     private Double smsRate;
     private Integer billableSheetsOfPaper;
-    private String costPostage;
+    private String postageType;
 
     public Notification(String content){
         JSONObject responseBodyAsJson = new JSONObject(content);
@@ -88,13 +88,13 @@ public class Notification {
             internationalRateMultiplier = costDetails.isNull("international_rate_multiplier") ? null : costDetails.getDouble("international_rate_multiplier");
             smsRate = costDetails.isNull("sms_rate") ? null : costDetails.getDouble("sms_rate");
             billableSheetsOfPaper = costDetails.isNull("billable_sheets_of_paper") ? null : costDetails.getInt("billable_sheets_of_paper");
-            costPostage = costDetails.isNull("postage") ? null : costDetails.getString("postage");
+            postageType = costDetails.isNull("postage") ? null : costDetails.getString("postage");
         } else {
             billableSmsFragments = null;
             internationalRateMultiplier = null;
             smsRate = null;
             billableSheetsOfPaper = null;
-            costPostage = null;
+            postageType = null;
         }
     }
 
@@ -222,8 +222,8 @@ public class Notification {
         return Optional.ofNullable(billableSheetsOfPaper);
     }
 
-    public Optional<String> getCostPostage() {
-        return Optional.ofNullable(costPostage);
+    public Optional<String> getPostageType() {
+        return Optional.ofNullable(postageType);
     }
 
     @Override
@@ -258,7 +258,7 @@ public class Notification {
                 ", internationalRateMultiplier=" + internationalRateMultiplier +
                 ", smsRate=" + smsRate +
                 ", billableSheetsOfPaper=" + billableSheetsOfPaper +
-                ", costPostage='" + costPostage + '\'' +
+                ", postageType='" + postageType + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/service/notify/Notification.java
+++ b/src/main/java/uk/gov/service/notify/Notification.java
@@ -27,8 +27,6 @@ public class Notification {
     private ZonedDateTime sentAt;
     private ZonedDateTime completedAt;
     private ZonedDateTime estimatedDelivery;
-//     private ZonedDateTime scheduledFor;
-//     private String oneClickUnsubscribe;
     private String createdByName;
     private boolean isCostDataReady;
     private double costInPounds;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=5.1.0-RELEASE
+project.version=5.2.0-RELEASE

--- a/src/test/java/uk/gov/service/notify/NotificationListTest.java
+++ b/src/test/java/uk/gov/service/notify/NotificationListTest.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 
-
 public class NotificationListTest {
     @Test
     public void testNotificationList_canCreateObjectFromJson() {
@@ -39,6 +38,16 @@ public class NotificationListTest {
         email.put("created_at", "2016-03-01T08:30:00.000Z");
         email.put("sent_at", "2016-03-01T08:30:03.000Z");
         email.put("completed_at", "2016-03-01T08:30:43.000Z");
+        email.put("is_cost_data_ready", true);
+        email.put("cost_in_pounds", 1.23);
+
+        JSONObject costDetails = new JSONObject();
+        costDetails.put("billable_sms_fragments", 5);
+        costDetails.put("international_rate_multiplier", 1.2);
+        costDetails.put("sms_rate", 0.05);
+        costDetails.put("billable_sheets_of_paper", 2);
+        costDetails.put("postage", "first_class");
+        email.put("cost_details", costDetails);
 
         JSONObject sms = new JSONObject();
         sms.put("id", id);
@@ -52,7 +61,7 @@ public class NotificationListTest {
         sms.put("line_5", null);
         sms.put("line_6", null);
         sms.put("postcode", null);
-        sms.put("type", "email");
+        sms.put("type", "sms");
         sms.put("status", "delivered");
         template.put("id", templateId);
         template.put("version", 1);
@@ -63,6 +72,16 @@ public class NotificationListTest {
         sms.put("created_at", "2016-03-01T08:30:00.000Z");
         sms.put("sent_at", "2016-03-01T08:30:03.000Z");
         sms.put("completed_at", "2016-03-01T08:30:43.000Z");
+        sms.put("is_cost_data_ready", true);
+        sms.put("cost_in_pounds", 0.15);
+
+        JSONObject smsCostDetails = new JSONObject();
+        smsCostDetails.put("billable_sms_fragments", 1);
+        smsCostDetails.put("international_rate_multiplier", null);
+        smsCostDetails.put("sms_rate", 0.15);
+        smsCostDetails.put("billable_sheets_of_paper", null);
+        smsCostDetails.put("postage", null);
+        sms.put("cost_details", smsCostDetails);
 
         JSONObject letter = new JSONObject();
         letter.put("id", id);
@@ -77,7 +96,7 @@ public class NotificationListTest {
         letter.put("line_6", null);
         letter.put("postcode", "SW1 1AA");
         letter.put("postage", "first");
-        letter.put("type", "email");
+        letter.put("type", "letter");
         letter.put("status", "delivered");
         template.put("id", templateId);
         template.put("version", 1);
@@ -88,6 +107,16 @@ public class NotificationListTest {
         letter.put("created_at", "2016-03-01T08:30:00.000Z");
         letter.put("sent_at", "2016-03-01T08:30:03.000Z");
         letter.put("completed_at", "2016-03-01T08:30:43.000Z");
+        letter.put("is_cost_data_ready", true);
+        letter.put("cost_in_pounds", 0.60);
+
+        JSONObject letterCostDetails = new JSONObject();
+        letterCostDetails.put("billable_sms_fragments", null);
+        letterCostDetails.put("international_rate_multiplier", null);
+        letterCostDetails.put("sms_rate", null);
+        letterCostDetails.put("billable_sheets_of_paper", 1);
+        letterCostDetails.put("postage", "first");
+        letter.put("cost_details", letterCostDetails);
 
         JSONArray listNotifications = new JSONArray();
         listNotifications.add(email);

--- a/src/test/java/uk/gov/service/notify/domain/NotifyNotificationResponse.java
+++ b/src/test/java/uk/gov/service/notify/domain/NotifyNotificationResponse.java
@@ -60,6 +60,75 @@ public class NotifyNotificationResponse {
         }
     }
 
+    public static class CostDetails {
+        private final Integer billableSmsFragments;
+        private final Double internationalRateMultiplier;
+        private final Double smsRate;
+        private final Integer billableSheetsOfPaper;
+        private final String postage;
+
+        public CostDetails(@JsonProperty("billable_sms_fragments") Integer billableSmsFragments,
+                           @JsonProperty("international_rate_multiplier") Double internationalRateMultiplier,
+                           @JsonProperty("sms_rate") Double smsRate,
+                           @JsonProperty("billable_sheets_of_paper") Integer billableSheetsOfPaper,
+                           @JsonProperty("postage") String postage) {
+            this.billableSmsFragments = billableSmsFragments;
+            this.internationalRateMultiplier = internationalRateMultiplier;
+            this.smsRate = smsRate;
+            this.billableSheetsOfPaper = billableSheetsOfPaper;
+            this.postage = postage;
+        }
+
+        @JsonProperty("billable_sms_fragments")
+        public Integer getBillableSmsFragments() {
+            return billableSmsFragments;
+        }
+
+        @JsonProperty("international_rate_multiplier")
+        public Double getInternationalRateMultiplier() {
+            return internationalRateMultiplier;
+        }
+
+        @JsonProperty("sms_rate")
+        public Double getSmsRate() {
+            return smsRate;
+        }
+
+        @JsonProperty("billable_sheets_of_paper")
+        public Integer getBillableSheetsOfPaper() {
+            return billableSheetsOfPaper;
+        }
+
+        @JsonProperty("postage")
+        public String getPostage() {
+            return postage;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CostDetails that = (CostDetails) o;
+            return Objects.equals(billableSmsFragments, that.billableSmsFragments) && Objects.equals(internationalRateMultiplier, that.internationalRateMultiplier) && Objects.equals(smsRate, that.smsRate) && Objects.equals(billableSheetsOfPaper, that.billableSheetsOfPaper) && Objects.equals(postage, that.postage);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(billableSmsFragments, internationalRateMultiplier, smsRate, billableSheetsOfPaper, postage);
+        }
+
+        @Override
+        public String toString() {
+            return "CostDetails{" +
+                    "billableSmsFragments=" + billableSmsFragments +
+                    ", internationalRateMultiplier=" + internationalRateMultiplier +
+                    ", smsRate=" + smsRate +
+                    ", billableSheetsOfPaper=" + billableSheetsOfPaper +
+                    ", postage='" + postage + '\'' +
+                    '}';
+        }
+    }
+
     private final UUID id;
     private final String reference;
     private final String emailAddress;
@@ -81,6 +150,10 @@ public class NotifyNotificationResponse {
     private final ZonedDateTime sentAt;
     private final ZonedDateTime completedAt;
 
+    private final boolean isCostDataReady;
+    private final double costInPounds;
+    private final CostDetails costDetails;
+
     public NotifyNotificationResponse(@JsonProperty("id") UUID id,
                                       @JsonProperty("reference") String reference,
                                       @JsonProperty("email_address") String emailAddress,
@@ -100,7 +173,10 @@ public class NotifyNotificationResponse {
                                       @JsonProperty("created_at") ZonedDateTime createdAt,
                                       @JsonProperty("created_by_name") String createdByName,
                                       @JsonProperty("sent_at") ZonedDateTime sentAt,
-                                      @JsonProperty("completed_at") ZonedDateTime completedAt) {
+                                      @JsonProperty("completed_at") ZonedDateTime completedAt,
+                                      @JsonProperty("is_cost_data_ready") boolean isCostDataReady,
+                                      @JsonProperty("cost_in_pounds") double costInPounds,
+                                      @JsonProperty("cost_details") CostDetails costDetails) {
 
         this.id = id;
         this.reference = reference;
@@ -122,6 +198,9 @@ public class NotifyNotificationResponse {
         this.createdByName = createdByName;
         this.sentAt = sentAt;
         this.completedAt = completedAt;
+        this.isCostDataReady = isCostDataReady;
+        this.costInPounds = costInPounds;
+        this.costDetails = costDetails;
     }
 
     @JsonProperty("id")
@@ -224,17 +303,54 @@ public class NotifyNotificationResponse {
         return completedAt;
     }
 
+    @JsonProperty("is_cost_data_ready")
+    public boolean isCostDataReady() {
+        return isCostDataReady;
+    }
+
+    @JsonProperty("cost_in_pounds")
+    public double getCostInPounds() {
+        return costInPounds;
+    }
+
+    @JsonProperty("cost_details")
+    public CostDetails getCostDetails() {
+        return costDetails;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         NotifyNotificationResponse that = (NotifyNotificationResponse) o;
-        return Objects.equals(id, that.id) && Objects.equals(reference, that.reference) && Objects.equals(emailAddress, that.emailAddress) && Objects.equals(phoneNumber, that.phoneNumber) && Objects.equals(line1, that.line1) && Objects.equals(line2, that.line2) && Objects.equals(line3, that.line3) && Objects.equals(line4, that.line4) && Objects.equals(line5, that.line5) && Objects.equals(line6, that.line6) && Objects.equals(line7, that.line7) && Objects.equals(type, that.type) && Objects.equals(status, that.status) && Objects.equals(template, that.template) && Objects.equals(body, that.body) && Objects.equals(subject, that.subject) && Objects.equals(createdAt, that.createdAt) && Objects.equals(createdByName, that.createdByName) && Objects.equals(sentAt, that.sentAt) && Objects.equals(completedAt, that.completedAt);
+        return isCostDataReady == that.isCostDataReady &&
+                Double.compare(that.costInPounds, costInPounds) == 0 &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(reference, that.reference) &&
+                Objects.equals(emailAddress, that.emailAddress) &&
+                Objects.equals(phoneNumber, that.phoneNumber) &&
+                Objects.equals(line1, that.line1) &&
+                Objects.equals(line2, that.line2) &&
+                Objects.equals(line3, that.line3) &&
+                Objects.equals(line4, that.line4) &&
+                Objects.equals(line5, that.line5) &&
+                Objects.equals(line6, that.line6) &&
+                Objects.equals(line7, that.line7) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(status, that.status) &&
+                Objects.equals(template, that.template) &&
+                Objects.equals(body, that.body) &&
+                Objects.equals(subject, that.subject) &&
+                Objects.equals(createdAt, that.createdAt) &&
+                Objects.equals(createdByName, that.createdByName) &&
+                Objects.equals(sentAt, that.sentAt) &&
+                Objects.equals(completedAt, that.completedAt) &&
+                Objects.equals(costDetails, that.costDetails);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, reference, emailAddress, phoneNumber, line1, line2, line3, line4, line5, line6, line7, type, status, template, body, subject, createdAt, createdByName, sentAt, completedAt);
+        return Objects.hash(id, reference, emailAddress, phoneNumber, line1, line2, line3, line4, line5, line6, line7, type, status, template, body, subject, createdAt, createdByName, sentAt, completedAt, isCostDataReady, costInPounds, costDetails);
     }
 
     @Override
@@ -260,6 +376,9 @@ public class NotifyNotificationResponse {
                 ", createdByName='" + createdByName + '\'' +
                 ", sentAt=" + sentAt +
                 ", completedAt=" + completedAt +
+                ", isCostDataReady=" + isCostDataReady +
+                ", costInPounds=" + costInPounds +
+                ", costDetails=" + costDetails +
                 '}';
     }
 }

--- a/src/test/resources/v2_notifications_response.json
+++ b/src/test/resources/v2_notifications_response.json
@@ -11,7 +11,6 @@
       "line_4": "a line 4",
       "line_5": "a line 5",
       "line_6": "a line 6",
-      "line_7": "a line 7",
       "type": "a type",
       "status": "a status",
       "template": {
@@ -24,7 +23,16 @@
       "created_at": "2024-05-10T16:40:14Z",
       "created_by_name": "a created_by_name",
       "sent_at": "2024-05-10T16:40:14Z",
-      "completed_at": "2024-05-10T16:40:14Z"
+      "completed_at": "2024-05-10T16:40:14Z",
+      "is_cost_data_ready": true,
+      "cost_in_pounds": 1.23,
+      "cost_details": {
+        "billable_sms_fragments": 5,
+        "international_rate_multiplier": 1.2,
+        "sms_rate": 0.05,
+        "billable_sheets_of_paper": 2,
+        "postage": "first_class"
+      }
     }
   ],
   "links": {


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
New fields have been added to the response of `get_notification(notificationId)` endpoint
- cost_in_pounds
- is_cost_data_ready
- cost_details:
-- **Nested fields for letters**:
--- billable_sheets_of_paper
--- postage
-- **Nested fields for sms**:
--- billable_sms_fragments
--- international_rate_multiplier
--- sms_rate
 
Based on the addition this PR updates our client documentation to showcase an aligned response for the endpoint

### Related task : 
[3. Add GET notification cost data to API clients and API client docs](https://trello.com/c/5VZrBNpU/845-3-add-get-notification-cost-data-to-api-clients-and-api-client-docs)

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - [x] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_java.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number
    - [x] in `src/main/resources/application.properties`
    - [x] in `pom.xml`
