### PR TITLE
Bump commons-io from 2.8.0 to 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.1-RELEASE
+* Bump commons-io from 2.8.0 to 2.17.0
+
 ## 5.2.0-RELEASE
 * Added fields related to cost data in response:
   * `is_cost_data_ready`: This field is true if cost data is ready, and false if it isn't (Boolean).

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.gov.service.notify</groupId>
     <artifactId>notifications-java-client</artifactId>
-    <version>5.2.0-RELEASE</version>
+    <version>5.2.1-RELEASE</version>
     <packaging>jar</packaging>
 
     <name>GOV.UK Notify Java client</name>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
+            <version>2.17.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@
 # - PATCH version when you make backwards-compatible bug fixes.
 #
 # -- http://semver.org/
-project.version=5.2.0-RELEASE
+project.version=5.2.1-RELEASE


### PR DESCRIPTION
Re-opens https://github.com/alphagov/notifications-java-client/pull/247 with contributor permissions so that CI will run the tests.

Closes #247 

