### PR TITLE
Make the integration tests compatible with the dev environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ RUN \
     echo "Install Debian packages" \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+    awscli \
     make \
     git \
-    gnupg
+    gnupg \
+    jq
 
 WORKDIR /var/project
+COPY . .

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: ## Run tests
 
 .PHONY: integration-test
 integration-test: ## Run integration tests
-	mvn --batch-mode clean integration-test
+	mvn --batch-mode clean verify -Dgpg.skip
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker: ## Prepare the Docker builder image

--- a/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
+++ b/src/test/java/uk/gov/service/notify/ClientIntegrationTestIT.java
@@ -527,11 +527,11 @@ public class ClientIntegrationTestIT {
                 }
 
                 count += 1;
-                if (count > 10) { // total time slept at this point is 55 seconds
+                if (count > 24) { // total time slept at this point is 120 seconds
                     throw e;
                 } else {
                     try {
-                        Thread.sleep(count * 1000);
+                        Thread.sleep(5000);
                     } catch (InterruptedException e1) {
                         Thread.currentThread().interrupt();
                     }


### PR DESCRIPTION
[Trello card](https://trello.com/c/D1m5uleD/952-run-api-client-integration-tests-as-part-of-new-pipeline)

Some small updates to make the integration tests runnable in the dev environments via the new deploy pipeline.

[Tested in dev-a](https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/162) (5 times in a row to check for flakiness)